### PR TITLE
refactor main to use run pattern and delete go binary from repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,15 +8,20 @@ import (
 )
 
 func main() {
-	cfg, err := config.Get()
-	if err != nil {
+	if err := run(os.Args); err != nil {
 		out.Error(err)
 		os.Exit(1)
+	}
+}
+
+// run the dp-cli application
+func run(args []string) error {
+	cfg, err := config.Get()
+	if err != nil {
+		return err
 	}
 
 	root := cmd.Load(cfg)
 
-	if err := root.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return root.Execute()
 }


### PR DESCRIPTION
 - Refactored main to use new run pattern.
- deleted the `dp-cli` go binary from the repo - binary shouldn't be commited.