### PR TITLE
Project generation bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=bash
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-TEMPLATES_DIR:=$(ROOT_DIR)/project-generation/content/templates
+TEMPLATES_DIR:=$(ROOT_DIR)/project_generation/content/templates
 VERSION:=$(shell git describe --tags --dirty)
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,12 @@ SHELL=bash
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 TEMPLATES_DIR:=$(ROOT_DIR)/project-generation/content/templates
+VERSION:=$(shell git describe --tags --dirty)
 
 build:
-	go build -ldflags="-X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
+	go build -ldflags="-X 'github.com/ONSdigital/dp-cli/cmd.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
 
 install:
-	go install -ldflags="-X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
-
-echo:
-	echo $(TEMPLATES_DIR)
+	go install -ldflags="-X 'github.com/ONSdigital/dp-cli/cmd.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
 
 .PHONY: install echo

--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -18,14 +18,12 @@ var (
 	onsDigitalPath       string
 	hierarchyBuilderPath string
 	codeListScriptsPath  string
-	appVersion           string
+	appVersion           = "development"
 )
 
 func Load(cfg *config.Config) *cobra.Command {
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r = rand.New(s1)
-
-	appVersion = "v0.0.1"
 
 	goPath = os.Getenv("GOPATH")
 

--- a/project_generation/content/templates/Dockerfile.concourse.tmpl
+++ b/project_generation/content/templates/Dockerfile.concourse.tmpl
@@ -2,7 +2,6 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 
 WORKDIR /app/
 
-COPY templates templates
 COPY {{.Name}} .
 
 CMD ./{{.Name}}

--- a/project_generation/content/templates/ci/build.tmpl
+++ b/project_generation/content/templates/ci/build.tmpl
@@ -6,11 +6,10 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tags: {{.GoVersion}}
+    tag: {{.GoVersion}}
 
 inputs:
   - name: {{.Name}}
-    path: go/src/github.com/ONSdigital/{{.Name}}
 
 outputs:
   - name: build
@@ -19,4 +18,4 @@ caches:
   - path: go/
 
 run:
-  path: go/src/github.com/ONSdigital/{{.Name}}/ci/scripts/build.sh
+  path: {{.Name}}/ci/scripts/build.sh

--- a/project_generation/content/templates/ci/scripts/build.tmpl
+++ b/project_generation/content/templates/ci/scripts/build.tmpl
@@ -1,11 +1,6 @@
 #!/bin/bash -eux
 
-cwd=$(pwd)
-
-export GOPATH=$cwd/go
-
-pushd {.Name}
-  make build && mv build/$(go env GOOS)-$(go env GOARCH)/* $cwd/build
-  cp -r templates $cwd/build
-  cp Dockerfile.concourse $cwd/build
+pushd {{.Name}}
+  make build
+  cp build/{{.Name}} Dockerfile.concourse ../build
 popd

--- a/project_generation/content/templates/ci/scripts/unit.tmpl
+++ b/project_generation/content/templates/ci/scripts/unit.tmpl
@@ -1,7 +1,5 @@
 #!/bin/bash -eux
 
-export GOPATH=$(pwd)/go
-
 pushd {.Name}
   make test
 popd

--- a/project_generation/content/templates/ci/unit.tmpl
+++ b/project_generation/content/templates/ci/unit.tmpl
@@ -10,7 +10,9 @@ image_resource:
 
 inputs:
   - name: {{.Name}}
-    path: go/src/github.com/ONSdigital/{{.Name}}
+
+  caches:
+  - path: go/
 
 run:
-  path: go/src/github.com/ONSdigital/{{.Name}}/ci/scripts/unit.sh
+  path: {{.Name}}/ci/scripts/unit.sh

--- a/project_generation/content/templates/nomad.tmpl
+++ b/project_generation/content/templates/nomad.tmpl
@@ -12,7 +12,7 @@ job "{{.Name}}" {
   }
 
   group "web" {
-    count = {{"{{"}}WEB_TASK_COUNT{{"}}"}}
+    count = ""{{"{{"}}WEB_TASK_COUNT{{"}}"}}""
 
     constraint {
       attribute = "${node.class}"

--- a/project_generation/content/templates/nomad.tmpl
+++ b/project_generation/content/templates/nomad.tmpl
@@ -12,7 +12,7 @@ job "{{.Name}}" {
   }
 
   group "web" {
-    count = ""{{"{{"}}WEB_TASK_COUNT{{"}}"}}""
+    count = "{{"{{"}}WEB_TASK_COUNT{{"}}"}}"
 
     constraint {
       attribute = "${node.class}"

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -57,6 +57,8 @@ func configureAndValidateArguments(ctx context.Context, appName, projectType, pr
 			Validator: ValidateGoVersion,
 		}
 		gv = listOfArguments["goVersion"].OutputVal
+	} else {
+		gv = goVersion
 	}
 
 	if port == "" {

--- a/project_generation/manifest.go
+++ b/project_generation/manifest.go
@@ -3,19 +3,19 @@ package project_generation
 var genericFiles = []fileGen{
 	{
 		templatePath: "readme",
-		outputPath:   "readme",
+		outputPath:   "README",
 		extension:    ".md",
 		filePrefix:   "",
 	},
 	{
 		templatePath: "contributing",
-		outputPath:   "contributing",
+		outputPath:   "CONTRIBUTING",
 		extension:    ".md",
 		filePrefix:   "",
 	},
 	{
 		templatePath: "license",
-		outputPath:   "license",
+		outputPath:   "LICENSE",
 		extension:    ".md",
 		filePrefix:   "",
 	},
@@ -57,12 +57,14 @@ var applicationFiles = []fileGen{
 		outputPath:   "ci/scripts/build",
 		extension:    ".sh",
 		filePrefix:   "",
+		executable:   true,
 	},
 	{
 		templatePath: "ci/scripts/unit",
 		outputPath:   "ci/scripts/unit",
 		extension:    ".sh",
 		filePrefix:   "",
+		executable:   true,
 	},
 	{
 		templatePath: "config/config",

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"os"
+	"path/filepath"
 	"text/template"
 
 	"github.com/ONSdigital/log.go/log"
@@ -58,11 +59,11 @@ func GenerateProject(appName, projType, projectLocation, goVer, port string, rep
 	}
 	// If repository was created then this would have already been offered
 	if !repositoryCreated {
-		OfferPurgeProjectDestination(ctx, pl, an)
+		OfferPurgeProjectDestination(ctx, filepath.Join(pl, an))
 	}
 
 	newApp := application{
-		pathToRepo:    pl + an + "/",
+		pathToRepo:    filepath.Join(pl, an),
 		projectType:   ProjectType(pt),
 		name:          an,
 		templateModel: PopulateTemplateModel(an, gv, prt),
@@ -112,32 +113,32 @@ func GenerateProject(appName, projType, projectLocation, goVer, port string, rep
 
 // createGenericContentDirectoryStructure will create child directories for Generic content at a given path
 func (a application) createGenericContentDirectoryStructure() error {
-	return os.MkdirAll(a.pathToRepo+".github", os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo,".github"), os.ModePerm)
 }
 
 // createApplicationContentDirectoryStructure will create child directories for Application content at a given path
 func (a application) createApplicationContentDirectoryStructure() error {
-	os.MkdirAll(a.pathToRepo+"config", os.ModePerm)
-	os.MkdirAll(a.pathToRepo+"ci/scripts", os.ModePerm)
+	os.MkdirAll(filepath.Join(a.pathToRepo,"config"), os.ModePerm)
+	os.MkdirAll(filepath.Join(a.pathToRepo,"ci/scripts"), os.ModePerm)
 	return nil
 }
 
 // createAPIContentDirectoryStructure will create child directories for API content at a given path
 func (a application) createAPIContentDirectoryStructure() error {
-	return os.MkdirAll(a.pathToRepo+"api", os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo,"api"), os.ModePerm)
 }
 
 // createControllerContentDirectoryStructure will create child directories for Controller content at a given path
 func (a application) createControllerContentDirectoryStructure() error {
-	err := os.MkdirAll(a.pathToRepo+"handlers", os.ModePerm)
+	err := os.MkdirAll(filepath.Join(a.pathToRepo,"handlers"), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(a.pathToRepo+"routes", os.ModePerm)
+	err = os.MkdirAll(filepath.Join(a.pathToRepo,"routes"), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(a.pathToRepo+"mapper", os.ModePerm)
+	err = os.MkdirAll(filepath.Join(a.pathToRepo,"mapper"), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -147,7 +148,7 @@ func (a application) createControllerContentDirectoryStructure() error {
 
 // createEventDrivenContentDirectoryStructure will create child directories for Event Driven content at a given path
 func (a application) createEventDrivenContentDirectoryStructure() error {
-	return os.MkdirAll(a.pathToRepo+"event", os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo,"event"), os.ModePerm)
 }
 
 // generateGenericContent will create all files for Generic content
@@ -267,13 +268,14 @@ func (a application) generateBatchOfFileTemplates(filesToGen []fileGen) error {
 
 // generateFileFromTemplate will generate a single file from templates
 func (a application) generateFileFromTemplate(fileToGen fileGen) (err error) {
-	outputFilePath := a.pathToRepo + fileToGen.filePrefix + fileToGen.outputPath + fileToGen.extension
+	outputFilename := fileToGen.filePrefix + fileToGen.outputPath + fileToGen.extension
+	outputFilePath := filepath.Join(a.pathToRepo,outputFilename)
 	f, err := os.Create(outputFilePath)
 	if err != nil {
 		return err
 	}
 	writer := bufio.NewWriter(f)
-	tmpl := template.Must(template.ParseFiles(templatesPath+"/" + fileToGen.templatePath + ".tmpl"))
+	tmpl := template.Must(template.ParseFiles(filepath.Join(templatesPath, fileToGen.templatePath + ".tmpl")))
 
 	defer func() {
 		ferr := writer.Flush()

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -30,6 +30,7 @@ type fileGen struct {
 	outputPath   string
 	extension    string
 	filePrefix   string
+	executable   bool
 }
 
 type ProjectType string
@@ -266,7 +267,8 @@ func (a application) generateBatchOfFileTemplates(filesToGen []fileGen) error {
 
 // generateFileFromTemplate will generate a single file from templates
 func (a application) generateFileFromTemplate(fileToGen fileGen) (err error) {
-	f, err := os.Create(a.pathToRepo + fileToGen.filePrefix + fileToGen.outputPath + fileToGen.extension)
+	outputFilePath := a.pathToRepo + fileToGen.filePrefix + fileToGen.outputPath + fileToGen.extension
+	f, err := os.Create(outputFilePath)
 	if err != nil {
 		return err
 	}
@@ -287,6 +289,13 @@ func (a application) generateFileFromTemplate(fileToGen fileGen) (err error) {
 	err = tmpl.Execute(writer, a.templateModel)
 	if err != nil {
 		return err
+	}
+
+	if fileToGen.executable {
+		err = os.Chmod(outputFilePath,os.ModePerm)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -44,7 +44,7 @@ const (
 )
 
 // To be replaced by `make install` with the user's own templates path
-var templatesPath string = "/Users/USERNAME/dev/ons/dp/dp-cli/project-generation/content/templates"
+var templatesPath string = "/Users/USERNAME/dev/ons/dp/dp-cli/project_generation/content/templates"
 
 // GenerateProject is the entry point into generating a project
 func GenerateProject(appName, projType, projectLocation, goVer, port string, repositoryCreated bool) error {

--- a/repository_creation/edit_repository.go
+++ b/repository_creation/edit_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/ONSdigital/log.go/log"
 	"os/exec"
+	"path/filepath"
 )
 
 // CloneRepository will clone a given repository at a given location,
@@ -35,7 +36,7 @@ func PushToRepo(ctx context.Context, projectLocation, appName string) error {
 		return err
 	}
 	cmd := exec.Command("git", "push", "-u", "origin", "feature/boilerplate-generation")
-	cmd.Dir = projectLocation + appName
+	cmd.Dir = filepath.Join(projectLocation, appName)
 	err = cmd.Run()
 	if err != nil {
 		log.Event(ctx, "error during push", log.Error(err))
@@ -47,7 +48,7 @@ func PushToRepo(ctx context.Context, projectLocation, appName string) error {
 // switchRepoToSSH will convert a given locations repositories connection from HTTPS to SSH
 func switchRepoToSSH(ctx context.Context, projectLocation, appName string) error {
 	cmd := exec.Command("git", "remote", "set-url", "origin", "git@github.com:"+org+"/"+appName+".git")
-	cmd.Dir = projectLocation + appName
+	cmd.Dir = filepath.Join(projectLocation, appName)
 	err := cmd.Run()
 	if err != nil {
 		log.Event(ctx, "switching origin access protocols from HTTPS to SSH", log.Error(err))
@@ -63,7 +64,7 @@ func createBoilerPlateBranch(ctx context.Context, projectLocation, appNme string
 		return err
 	}
 	cmd := exec.Command("git", "checkout", "-b", "feature/boilerplate-generation")
-	cmd.Dir = projectLocation + appNme
+	cmd.Dir = filepath.Join(projectLocation, appNme)
 	err = cmd.Run()
 	if err != nil {
 		log.Event(ctx, "error committing", log.Error(err))
@@ -80,7 +81,7 @@ func commitProject(ctx context.Context, projectLocation, appNme string) error {
 		return err
 	}
 	cmd := exec.Command("git", "commit", "-S", "-m", "initial commit, created via dp project generation tool")
-	cmd.Dir = projectLocation + appNme
+	cmd.Dir = filepath.Join(projectLocation, appNme)
 	err = cmd.Run()
 	if err != nil {
 		log.Event(ctx, "error committing", log.Error(err))
@@ -92,7 +93,7 @@ func commitProject(ctx context.Context, projectLocation, appNme string) error {
 // stageAllFiles will stage all files at a given directory
 func stageAllFiles(ctx context.Context, projectLocation, appNme string) error {
 	cmd := exec.Command("git", "add", "-A")
-	cmd.Dir = projectLocation + appNme
+	cmd.Dir = filepath.Join(projectLocation, appNme)
 	err := cmd.Run()
 	if err != nil {
 		log.Event(ctx, "error staging files", log.Error(err))


### PR DESCRIPTION
Fixes various bus in project generation, including…
- Capitalise generated markdown filenames
- Fix quotation of WEB_TASK_COUNT in nomad template
- Make generated scripts executable
- Get version from git commit on build
- Bring CI script templates up to go 1.13 compatibility
- Make script able to be run from any directory by making templates path absolute
- Embed version number from git history (based on release tags / commits)