### PR TITLE
Use fully qualified namespaces for git module

### DIFF
--- a/project_generation/content/templates/handlers/handlers.tmpl
+++ b/project_generation/content/templates/handlers/handlers.tmpl
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"{{.Name}}/config"
-	"{{.Name}}/mapper"
+	"github.com/ONSdigital/{{.Name}}/config"
+	"github.com/ONSdigital/{{.Name}}/mapper"
 	"encoding/json"
 	"github.com/ONSdigital/log.go/log"
 	"net/http"

--- a/project_generation/content/templates/main.tmpl
+++ b/project_generation/content/templates/main.tmpl
@@ -8,8 +8,8 @@ import (
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 
-	"{{.Name}}/config"
-	"{{.Name}}/routes"
+	"github.com/ONSdigital/{{.Name}}/config"
+	"github.com/ONSdigital/{{.Name}}/routes"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"

--- a/project_generation/content/templates/mapper/mapper.tmpl
+++ b/project_generation/content/templates/mapper/mapper.tmpl
@@ -2,7 +2,7 @@ package mapper
 
 import (
 	"context"
-	"{{.Name}}/config"
+	"github.com/ONSdigital/{{.Name}}/config"
 	"fmt"
 )
 

--- a/project_generation/content/templates/mapper/mapper_test.tmpl
+++ b/project_generation/content/templates/mapper/mapper_test.tmpl
@@ -2,7 +2,7 @@ package mapper
 
 import (
 	"context"
-	"dp-test-controller/config"
+	"github.com/ONSdigital/{{.Name}}/config"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/project_generation/content/templates/routes/routes.tmpl
+++ b/project_generation/content/templates/routes/routes.tmpl
@@ -3,8 +3,8 @@ package routes
 import (
     "context"
 
-	"{{.Name}}/config"
-	"{{.Name}}/handlers"
+	"github.com/ONSdigital/{{.Name}}/config"
+	"github.com/ONSdigital/{{.Name}}/handlers"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -376,7 +376,7 @@ func OptionPromptInput(ctx context.Context, prompt string, options ...string) (s
 
 // InitGoModules will initialise the go modules for a project at a given directory
 func InitGoModules(ctx context.Context, pathToRepo, name string) {
-	cmd := exec.Command("go", "mod", "init", name)
+	cmd := exec.Command("go", "mod", "init", "github.com/ONSdigital/"+name)
 	cmd.Dir = pathToRepo
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
The namespaces in generated projects were not fully qualified with github.com/ONSdigital

The initialises of git modules has been updated as well as all templates that were using the shorthand package names.