### PR TITLE
Fix indentaition in template for ci/unit.yml

### DIFF
--- a/project_generation/content/templates/ci/unit.tmpl
+++ b/project_generation/content/templates/ci/unit.tmpl
@@ -11,7 +11,7 @@ image_resource:
 inputs:
   - name: {{.Name}}
 
-  caches:
+caches:
   - path: go/
 
 run:


### PR DESCRIPTION
### What

Remove incorrect indentation in template for ci/unit.yml.
This caused the generated project to fail to run unit tests on CI.

### How to review

Ensure correct yaml indentation for affected line.

### Who can review

Anyone but me