### PR TITLE
Add dp-cli-config.yml filename to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
 /project_generation/generated/*
+dp-cli-config.yml
 
 dp-cli


### PR DESCRIPTION
The documentation says to create a `dp-cli-config.yml` file, but that file is not currently ignored. Rather than having to stash the change constantly, or risk committing a personal file, let's get git to ignore it for us!