### PR TITLE
fixed defect caused by variable scope

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -101,13 +101,15 @@ func createInstanceSubCommands(grp string, cfg *config.Config, env config.Enviro
 	commands := make([]*cobra.Command, 0)
 
 	for i, instance := range instances {
+		e := env
+		inst := instance
 		index := strconv.Itoa(i + 1)
 
 		instanceC := &cobra.Command{
 			Use:   index,
-			Short: fmt.Sprintf("ssh to %s %q (%s)", grp, instance.Name, instance.IPAddress),
+			Short: fmt.Sprintf("ssh to %s %q (%s)", grp, inst.Name, inst.IPAddress),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return ssh.Launch(cfg, env, instance)
+				return ssh.Launch(cfg, e, inst)
 			},
 		}
 


### PR DESCRIPTION
Fixed defect in instance subcommand where only ever connecting to last listed instance.

`env` and `instance` variable values changing with each iteration of loop. Created new local vars to prevent this happening.