### PR TITLE
Rename the built command from `dp-cli` to `dp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /project_generation/generated/*
 
 dp-cli
+dp

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ TEMPLATES_DIR:=$(ROOT_DIR)/project_generation/content/templates
 VERSION:=$(shell git describe --tags --dirty)
 
 build:
-	go build -ldflags="-X 'github.com/ONSdigital/dp-cli/cmd.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
+	go build -ldflags="-X 'github.com/ONSdigital/dp-cli/command.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'" github.com/ONSdigital/dp-cli/cmd/dp
 
 install:
-	go install -ldflags="-X 'github.com/ONSdigital/dp-cli/cmd.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'"
+	go install -ldflags="-X 'github.com/ONSdigital/dp-cli/command.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'" github.com/ONSdigital/dp-cli/cmd/dp
 
 .PHONY: install echo

--- a/README.md
+++ b/README.md
@@ -76,20 +76,20 @@ export DP_CLI_CONFIG="<YOUR_PATH>/dp-cli-config.yml"
 Build, install and start the cli:
 ```
 make install
-dp-cli
+dp
 ```
 Or to build a binary locally:
 ```
 make build
-./dp-cli
+./dp
 ```
 
 You should be presented you a help menu similar to:
 ```bash
-dp-cli is a command line client providing handy helper tools for ONS Digital Publishing software engineers
+dp is a command line client providing handy helper tools for ONS Digital Publishing software engineers
 
 Usage:
-  dp-cli [command]
+  dp [command]
 
 Available Commands:
   clean            Delete data from your local environment
@@ -103,9 +103,9 @@ Available Commands:
   version          Print the app version
 
 Flags:
-  -h, --help   help for dp-cli
+  -h, --help   help for dp
 
-Use "dp-cli [command] --help" for more information about a command.
+Use "dp [command] --help" for more information about a command.
 ```
 
 Use the available commands for more info on the functionality available.
@@ -133,11 +133,11 @@ environments:
 #### SSH command fails
 
 ```
-➜  dp-cli ssh develop
+➜  dp ssh develop
 ssh to develop
 ```
 
-If the SSH command fails, ensure that the `dp-cli remote allow` command has been run for the environment you want to SSH into.
+If the SSH command fails, ensure that the `dp remote allow` command has been run for the environment you want to SSH into.
 
 #### Remote Allow security group error
 
@@ -150,10 +150,10 @@ Depending on the command you're trying to run, and what you're trying to access,
 #### Remote Allow security group rule already exists error
 
 ```
-➜  dp-cli remote allow develop
-[dp-cli] allowing access to develop
+➜  dp remote allow develop
+[dp] allowing access to develop
 Error: error adding rules to bastionSG: InvalidPermission.Duplicate: the specified rule "peer: X.X.X.X/32, TCP, from port: 22, to port: 22, ALLOW" already exists
         status code: 400, request id: 26a61345-8391-4c65-bfd7-4f0052892b6b
 ```
 
-The error occurs when rules have previously been added and the command is run again. Use `dp-cli remote deny` to clear out existing rules and try again.
+The error occurs when rules have previously been added and the command is run again. Use `dp remote deny` to clear out existing rules and try again.

--- a/cmd/dp/main.go
+++ b/cmd/dp/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/ONSdigital/dp-cli/cmd"
+	"github.com/ONSdigital/dp-cli/command"
 	"github.com/ONSdigital/dp-cli/config"
 	"github.com/ONSdigital/dp-cli/out"
 )
@@ -15,14 +15,14 @@ func main() {
 	}
 }
 
-// run the dp-cli application
+// run the dp application
 func run(args []string) error {
 	cfg, err := config.Get()
 	if err != nil {
 		return err
 	}
 
-	root, err := cmd.Load(cfg)
+	root, err := command.Load(cfg)
 	if err != nil {
 		return err
 	}

--- a/command/clean.go
+++ b/command/clean.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/config"

--- a/command/create_repo.go
+++ b/command/create_repo.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/repository_creation"
@@ -28,4 +28,3 @@ func createGithubRepo() *cobra.Command {
 	command.Flags().String("strategy", "git", "which branching-strategy this is depended on; will configure branches. Currently supported 'git' and 'github'")
 	return command
 }
-

--- a/command/generate.go
+++ b/command/generate.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"context"

--- a/command/import_data.go
+++ b/command/import_data.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/config"

--- a/command/remote_access.go
+++ b/command/remote_access.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/aws"

--- a/command/root_command.go
+++ b/command/root_command.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"math/rand"
@@ -34,8 +34,8 @@ func Load(cfg *config.Config) (*cobra.Command, error) {
 	codeListScriptsPath = filepath.Join(onsDigitalPath, "dp-code-list-scripts/code-list-scripts")
 
 	root = &cobra.Command{
-		Use:   "dp-cli",
-		Short: "dp-cli is a command line client providing handy helper tools for ONS Digital Publishing software engineers",
+		Use:   "dp",
+		Short: "dp is a command line client providing handy helper tools for ONS Digital Publishing software engineers",
 	}
 
 	// register the root sub-commands.

--- a/command/spew.go
+++ b/command/spew.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/config"

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"fmt"

--- a/command/version.go
+++ b/command/version.go
@@ -1,4 +1,4 @@
-package cmd
+package command
 
 import (
 	"github.com/ONSdigital/dp-cli/out"
@@ -15,4 +15,3 @@ func versionSubCommand() *cobra.Command {
 		},
 	}
 }
-

--- a/customisemydata/neo4j.go
+++ b/customisemydata/neo4j.go
@@ -1,10 +1,10 @@
 package customisemydata
 
 import (
+	"fmt"
+	"github.com/ONSdigital/dp-cli/cli"
 	"github.com/ONSdigital/dp-cli/config"
 	"github.com/ONSdigital/dp-cli/out"
-	"github.com/ONSdigital/dp-cli/cli"
-	"fmt"
 
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
 )

--- a/out/output.go
+++ b/out/output.go
@@ -14,7 +14,7 @@ var (
 	warningC     = color.New(color.FgHiYellow)
 	errorBoldC   = color.New(color.Bold, color.FgHiRed)
 	errorC       = color.New(color.FgHiRed)
-	outPrefix    = "[dp-cli]"
+	outPrefix    = "[dp]"
 )
 
 type Level int

--- a/project_generation/COMPLETE_PROJECT_SETUP.md
+++ b/project_generation/COMPLETE_PROJECT_SETUP.md
@@ -19,7 +19,7 @@ There are three ways of creating a repository and using the boilerplate generati
 (note that `y` is also accepted - this is not case sensitive).
 
 ```shell script
-dp-cli generate-project --create-repository yes
+dp generate-project --create-repository yes
 ``` 
 If this method is chosen then there wil be numerous prompts such as the name of the application, 
 location to build it and the type of project it should boilerplate.
@@ -27,7 +27,7 @@ ____
 ### Second method - use command line arguments
 The second way to use this tool is to provide information via the command line as options like so
 ```shell script
-dp-cli generate-project --create-repository yes --name {name-of-repository} --project-location {location} --type {project-type}
+dp generate-project --create-repository yes --name {name-of-repository} --project-location {location} --type {project-type}
 ```
 If this method is chosen then there will be less prompts during the creation of the project
 ____
@@ -38,11 +38,11 @@ project - however this should be avoided
 
 Note: _`generate-project` can also be called after `create-repo` the order does not matter_ 
 ```shell script
-dp-cli generate-project
+dp generate-project
 ```
 
 After running follow the prompts then run the repo-creation tool
 ```shell script
-dp-cli create-repo github
+dp create-repo github
 ```
 And follow the prompts, alternatively provide command line arguments.

--- a/project_generation/README.md
+++ b/project_generation/README.md
@@ -16,7 +16,7 @@ git pull; make install;
 ```
 
 ```shell script
-dp-cli generate-project
+dp generate-project
 ``` 
 
 This tool can be used in conjunction with the repository creation tool, for further details read [COMPLETE_PROJECT_SETUP.md](COMPLETE_PROJECT_SETUP.md)

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -124,7 +124,6 @@ func ValidateAppDescription(ctx context.Context, description string) (string, er
 	return description, err
 }
 
-
 // ValidateProjectType will ensure that the project type provided by the users is one that can be boilerplate
 func ValidateProjectType(ctx context.Context, projectType string) (validatedProjectType string, err error) {
 	if projectType == "" {
@@ -185,10 +184,10 @@ func ValidateProjectDirectory(ctx context.Context, path, projectName string) err
 		log.Event(ctx, "file path to project location does not exists - for safety assuming wrong location was provided")
 		return err
 	}
-	projectPath := filepath.Join(path,projectName)
+	projectPath := filepath.Join(path, projectName)
 	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
 		// File path to project does exists but project directory does not exist at the given path
-		err := os.Mkdir(projectPath, os.ModeDir | os.ModePerm)
+		err := os.Mkdir(projectPath, os.ModeDir|os.ModePerm)
 		if err != nil {
 			log.Event(ctx, "error creating project directory", log.Error(err))
 			return err
@@ -212,7 +211,6 @@ func ValidateProjectDirectory(ctx context.Context, path, projectName string) err
 	//everything is good and nothing needs to be done
 	return nil
 }
-
 
 // ValidateBranchingStrategy will ensure that the strategy  provided by the user is one that can be boilerplate
 func ValidateBranchingStrategy(ctx context.Context, branchingStrategy string) (string, error) {

--- a/project_generation/manifest.go
+++ b/project_generation/manifest.go
@@ -139,20 +139,20 @@ var controllerFiles = []fileGen{
 
 var apiFiles = []fileGen{
 	//{
-		// TODO Swagger spec
-		// TODO api/API.go
-		// TODO api/API_test.go
-		// TODO api/Hello.go
-		// TODO api/hello_test.go
+	// TODO Swagger spec
+	// TODO api/API.go
+	// TODO api/API_test.go
+	// TODO api/Hello.go
+	// TODO api/hello_test.go
 	//},
 }
 
 var eventFiles = []fileGen{
 	//{
-		// Todo event/
-		// TODO Event
-		// TODO Consumer
-		// TODO Consumer_test
-		// TODO handler
+	// Todo event/
+	// TODO Event
+	// TODO Consumer
+	// TODO Consumer_test
+	// TODO handler
 	//},
 }

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -113,32 +113,32 @@ func GenerateProject(appName, projType, projectLocation, goVer, port string, rep
 
 // createGenericContentDirectoryStructure will create child directories for Generic content at a given path
 func (a application) createGenericContentDirectoryStructure() error {
-	return os.MkdirAll(filepath.Join(a.pathToRepo,".github"), os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo, ".github"), os.ModePerm)
 }
 
 // createApplicationContentDirectoryStructure will create child directories for Application content at a given path
 func (a application) createApplicationContentDirectoryStructure() error {
-	os.MkdirAll(filepath.Join(a.pathToRepo,"config"), os.ModePerm)
-	os.MkdirAll(filepath.Join(a.pathToRepo,"ci/scripts"), os.ModePerm)
+	os.MkdirAll(filepath.Join(a.pathToRepo, "config"), os.ModePerm)
+	os.MkdirAll(filepath.Join(a.pathToRepo, "ci/scripts"), os.ModePerm)
 	return nil
 }
 
 // createAPIContentDirectoryStructure will create child directories for API content at a given path
 func (a application) createAPIContentDirectoryStructure() error {
-	return os.MkdirAll(filepath.Join(a.pathToRepo,"api"), os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo, "api"), os.ModePerm)
 }
 
 // createControllerContentDirectoryStructure will create child directories for Controller content at a given path
 func (a application) createControllerContentDirectoryStructure() error {
-	err := os.MkdirAll(filepath.Join(a.pathToRepo,"handlers"), os.ModePerm)
+	err := os.MkdirAll(filepath.Join(a.pathToRepo, "handlers"), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(filepath.Join(a.pathToRepo,"routes"), os.ModePerm)
+	err = os.MkdirAll(filepath.Join(a.pathToRepo, "routes"), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(filepath.Join(a.pathToRepo,"mapper"), os.ModePerm)
+	err = os.MkdirAll(filepath.Join(a.pathToRepo, "mapper"), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (a application) createControllerContentDirectoryStructure() error {
 
 // createEventDrivenContentDirectoryStructure will create child directories for Event Driven content at a given path
 func (a application) createEventDrivenContentDirectoryStructure() error {
-	return os.MkdirAll(filepath.Join(a.pathToRepo,"event"), os.ModePerm)
+	return os.MkdirAll(filepath.Join(a.pathToRepo, "event"), os.ModePerm)
 }
 
 // generateGenericContent will create all files for Generic content
@@ -269,13 +269,13 @@ func (a application) generateBatchOfFileTemplates(filesToGen []fileGen) error {
 // generateFileFromTemplate will generate a single file from templates
 func (a application) generateFileFromTemplate(fileToGen fileGen) (err error) {
 	outputFilename := fileToGen.filePrefix + fileToGen.outputPath + fileToGen.extension
-	outputFilePath := filepath.Join(a.pathToRepo,outputFilename)
+	outputFilePath := filepath.Join(a.pathToRepo, outputFilename)
 	f, err := os.Create(outputFilePath)
 	if err != nil {
 		return err
 	}
 	writer := bufio.NewWriter(f)
-	tmpl := template.Must(template.ParseFiles(filepath.Join(templatesPath, fileToGen.templatePath + ".tmpl")))
+	tmpl := template.Must(template.ParseFiles(filepath.Join(templatesPath, fileToGen.templatePath+".tmpl")))
 
 	defer func() {
 		ferr := writer.Flush()
@@ -294,7 +294,7 @@ func (a application) generateFileFromTemplate(fileToGen fileGen) (err error) {
 	}
 
 	if fileToGen.executable {
-		err = os.Chmod(outputFilePath,os.ModePerm)
+		err = os.Chmod(outputFilePath, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/repository_creation/README.md
+++ b/repository_creation/README.md
@@ -14,7 +14,7 @@
 ___
 ### How to use
 1. (optional) Export the environment variable GITHUB_PERSONAL_ACCESS_TOKEN with your github personal access token
-2. Run `dp-cli repo-generation github`
+2. Run `dp repo-generation github`
 3. Enter your 'Personal Access Token' when prompted (if step 1. was not complete)
 4. Enter your Github handler when prompted
 5. Enter your repository name, note that if the repository is specific to Digital Publishing then prefix it with 'dp-'

--- a/repository_creation/create_repository.go
+++ b/repository_creation/create_repository.go
@@ -3,8 +3,8 @@ package repository_creation
 import (
 	"bufio"
 	"context"
-	"github.com/ONSdigital/dp-cli/project_generation"
 	"fmt"
+	"github.com/ONSdigital/dp-cli/project_generation"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/google/go-github/v28/github"
 	"github.com/spf13/cobra"
@@ -27,7 +27,7 @@ func RunGenerateRepo(cmd *cobra.Command, args []string) error {
 	token, _ := cmd.Flags().GetString("token")
 	branchStrategyInput, _ := cmd.Flags().GetString("strategy")
 	branchStrategy := strings.ToLower(strings.TrimSpace(branchStrategyInput))
-	_, err = GenerateGithub(nameOfApp,"", "", token, branchStrategy)
+	_, err = GenerateGithub(nameOfApp, "", "", token, branchStrategy)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func setTeamsAndCollaborators(ctx context.Context, client *github.Client, repoNa
 		return err
 	}
 
-	user , resp,  err := client.Users.Get(ctx,"")
+	user, resp, err := client.Users.Get(ctx, "")
 	if err != nil {
 		log.Event(ctx, "unable to get current github user", log.Error(err), log.Data{"response": resp})
 	}
@@ -252,13 +252,13 @@ func getConfigurationsForNewRepo(name, description string, projType project_gene
 	}
 	if branchStrategy == "" {
 		prompt := "Please pick the branching strategy you wish this repo to use:"
-		options := []string{"github flow","git flow"}
+		options := []string{"github flow", "git flow"}
 		ctx := context.Background()
 		branchStrategy, err := project_generation.OptionPromptInput(ctx, prompt, options...)
 		if err != nil {
 			log.Event(ctx, "error getting branch strategy", log.Error(err))
 		}
-		branchStrategy = strings.Replace(branchStrategy, " flow","", -1)
+		branchStrategy = strings.Replace(branchStrategy, " flow", "", -1)
 	}
 	if projType == "generic-project" || branchStrategy == "github" {
 		defaultBranch = "master"


### PR DESCRIPTION
I have renamed the `dp-cli` command to `dp`. However the repository has remained as `dp-cli` so I have instead moved the main.go into `cmd/dp`. Unfortunately there was already an existing directory called `cmd` so I have renamed this `command`. Longer term we should probably restructure the repo but this is minimal for now that preserves the convention of a main command being in a package of th same name (ie. `dp` is in a directory called `dp`).

Anyone can review.