### PR TITLE
Add port forwarding (tunnelling) to dp ssh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,7 @@ build:
 install:
 	go install -ldflags="-X 'github.com/ONSdigital/dp-cli/command.appVersion=$(VERSION)' -X 'github.com/ONSdigital/dp-cli/project_generation.templatesPath=$(TEMPLATES_DIR)'" github.com/ONSdigital/dp-cli/cmd/dp
 
-.PHONY: install echo
+test:
+	go test -race -cover ./...
+
+.PHONY: buid install test

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/ONSdigital/dp-cli/aws"
 	"github.com/ONSdigital/dp-cli/config"
@@ -13,7 +15,7 @@ import (
 )
 
 // Open an ssh connect to the specified environment
-func Launch(cfg *config.Config, env config.Environment, instance aws.EC2Result) error {
+func Launch(cfg *config.Config, env config.Environment, instance aws.EC2Result, portArgs *[]string) error {
 	if len(cfg.SSHUser) == 0 {
 		out.Highlight(out.WARN, "no %s is defined in your configuration file you can view the app configuration values using the %s command\n", "ssh user", "spew config")
 		return errors.New("missing ssh user in config file")
@@ -25,8 +27,19 @@ func Launch(cfg *config.Config, env config.Environment, instance aws.EC2Result) 
 	out.Highlight(lvl, "[IP: %s | Name: %s | Groups %s]\n", instance.IPAddress, instance.Name, instance.AnsibleGroups)
 
 	pwd := filepath.Join(cfg.DPSetupPath, "ansible")
+	args := []string{"-F", "ssh.cfg"}
+	if portArgs != nil {
+		for _, portArg := range *portArgs {
+			sshPortArgs, err := getSSHPortArguments(portArg)
+			if err != nil {
+				return err
+			}
+			args = append(args, sshPortArgs...)
+		}
+	}
 	unixUser := fmt.Sprintf("%s@%s", cfg.SSHUser, instance.IPAddress)
-	return execCommand(pwd, "ssh", "-F", "ssh.cfg", unixUser)
+	args = append(args, unixUser)
+	return execCommand(pwd, "ssh", args...)
 }
 
 func execCommand(pwd string, command string, arg ...string) error {
@@ -40,4 +53,21 @@ func execCommand(pwd string, command string, arg ...string) error {
 		return err
 	}
 	return nil
+}
+
+func getSSHPortArguments(portArg string) ([]string, error) {
+	validPort := regexp.MustCompile(`^(([0-9]+):)?([0-9]+)$`)
+	if !validPort.MatchString(portArg) {
+		return nil, errors.New(fmt.Sprintf("'%s' is not a valid port forwarding argument", portArg))
+	}
+
+	ports := strings.Split(portArg, ":")
+	var sshPortArg string
+	if len(ports) == 1 {
+		sshPortArg = fmt.Sprintf("%s:localhost:%s", ports[0], ports[0])
+	} else {
+		sshPortArg = fmt.Sprintf("%s:localhost:%s", ports[0], ports[1])
+	}
+
+	return []string{"-L", sshPortArg}, nil
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -1,0 +1,66 @@
+package ssh
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetPortArguments(t *testing.T) {
+	Convey("Given port forwarding arguments need to be translated", t, func() {
+
+		Convey("When a single port is provided", func() {
+
+			sshArgs, err := getSSHPortArguments("11400")
+			Convey("Then there should be no error returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the ssh forwarding ports should match", func() {
+				So(sshArgs, ShouldNotBeEmpty)
+				So(sshArgs, ShouldHaveLength, 2)
+				So(sshArgs[0], ShouldResemble, "-L")
+				So(sshArgs[1], ShouldResemble, "11400:localhost:11400")
+			})
+		})
+
+		Convey("When different local and remote ports are provided", func() {
+
+			sshArgs, err := getSSHPortArguments("11500:11400")
+			Convey("Then there should be no error returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the ssh forwarding ports should differ", func() {
+				So(sshArgs, ShouldNotBeEmpty)
+				So(sshArgs, ShouldHaveLength, 2)
+				So(sshArgs[0], ShouldResemble, "-L")
+				So(sshArgs[1], ShouldResemble, "11500:localhost:11400")
+			})
+		})
+
+		Convey("When invalid arguments are supplied", func() {
+			invalidCases := []string{
+				"moo",
+				":123",
+				"123:",
+				"123::123",
+				"123:123:123",
+				"",
+			}
+
+			for _, invalid := range invalidCases {
+				sshArgs, err := getSSHPortArguments(invalid)
+				Convey(fmt.Sprintf("Then there should be an error returned for '%s'", invalid), func() {
+					So(err, ShouldNotBeNil)
+					So(err.Error(), ShouldContainSubstring, "is not a valid port forwarding argument")
+				})
+
+				Convey(fmt.Sprintf("Then there should be no ssh arguments returnednfor '%s'", invalid), func() {
+					So(sshArgs, ShouldBeNil)
+				})
+			}
+		})
+	})
+}


### PR DESCRIPTION
Added port forwarding/tunnelling to the `dp ssh` command. I used the docker style of forwarding rules hence the `-p 123:456` style, although I think `--port` is clearer than Docker's `--publish` for the long form.

Anyone can review, but particularly those who use port forwarding a lot.