### PR TITLE
Update the link to the AWS credentials documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use the available commands for more info on the functionality available.
 
 `error creating group commands for env: develop: error fetching ec2: {"develop" "development"}: NoCredentialProviders: no valid providers in chain. Deprecated.`
 
-Ensure you have AWS credentials set up as documented here: https://github.com/ONSdigital/dp-setup/blob/develop/AWS-CREDENTIALS.md
+[Ensure you have AWS credentials set up](https://github.com/ONSdigital/dp/blob/master/guides/AWS_CREDENTIALS.md).
 
 If you do not want to set up separate profiles, another option is to not specify any profiles in your `dp-cli-config.yml`. That way the default credentials will be used.
 


### PR DESCRIPTION
Update the link to the AWS credentials documentation as it has been moved from dp-setup to dp.

🚨 Depends on: https://github.com/ONSdigital/dp/pull/106