### PR TITLE
Fix nomad plan for code generation

### DIFF
--- a/project_generation/content/templates/base-app/nomad.tmpl
+++ b/project_generation/content/templates/base-app/nomad.tmpl
@@ -106,7 +106,7 @@ job "{{.Name}}" {
       }
 
       service {
-        name = {{.Name}}
+        name = "{{.Name}}"
         port = "http"
         tags = ["publishing"]
 


### PR DESCRIPTION
### What

In publishing the code generation would create task with the service name not in quotes. This would cause an unknown token error. This adds the quotes in.

### Who can review

Anyone except me