### PR TITLE
Update repo generation tool templates

### DIFF
--- a/project_generation/content/templates/base-app/README.md.tmpl
+++ b/project_generation/content/templates/base-app/README.md.tmpl
@@ -16,8 +16,8 @@
 | ---------------------------- | --------- | -----------
 | BIND_ADDR                    | :{{.Port}}    | The host and port to bind to
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 10s       | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 1m        | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
 
 ### Contributing
 

--- a/project_generation/content/templates/base-app/config/config.go.tmpl
+++ b/project_generation/content/templates/base-app/config/config.go.tmpl
@@ -25,8 +25,8 @@ func Get() (*Config, error) {
 	cfg := &Config{
 		BindAddr:                   ":{{.Port}}",
 		GracefulShutdownTimeout:    5 * time.Second,
-		HealthCheckInterval:        10 * time.Second,
-		HealthCheckCriticalTimeout: time.Minute,
+		HealthCheckInterval:        30 * time.Second,
+		HealthCheckCriticalTimeout: 90 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/project_generation/content/templates/base-app/config/config_test.go.tmpl
+++ b/project_generation/content/templates/base-app/config/config_test.go.tmpl
@@ -19,7 +19,8 @@ func TestConfig(t *testing.T) {
 
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 1*time.Minute)
+				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
+				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/project_generation/content/templates/controller/README.md.tmpl
+++ b/project_generation/content/templates/controller/README.md.tmpl
@@ -16,8 +16,8 @@
 | ---------------------------- | --------- | -----------
 | BIND_ADDR                    | :{{.Port}}    | The host and port to bind to
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 10s       | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 1m        | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
 | HELLO_WORLD_EMPHASISE        | true      | Example boolean flag to control whether the 'Hello World' greeting should be emphasised with "!"
 
 ### Contributing

--- a/project_generation/content/templates/controller/config/config.go.tmpl
+++ b/project_generation/content/templates/controller/config/config.go.tmpl
@@ -26,8 +26,8 @@ func Get() (*Config, error) {
 	cfg := &Config{
 		BindAddr:                   ":{{.Port}}",
 		GracefulShutdownTimeout:    5 * time.Second,
-		HealthCheckInterval:        10 * time.Second,
-		HealthCheckCriticalTimeout: time.Minute,
+		HealthCheckInterval:        30 * time.Second,
+		HealthCheckCriticalTimeout: 90 * time.Second,
 		HelloWorldEmphasise:        true,
 	}
 


### PR DESCRIPTION
Update repo generation tool templates with the new default configuration for healthcheck

Defaults should be 30 seconds for health check interval and 90 seconds for health check critical timeout