### PR TITLE
`remote allow` does `deny` first (new `--no-deny` flag retains old behaviour/IPs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Command-line client providing *handy helper tools* for the ONS Digital Publishing software engineering team
 
-:warning: Still in active development. If you noticed and bugs/issues please open a Github issue.
+:warning: Still in active development. If you notice any bugs/issues please open a Github issue.
 
 ### Getting started
 

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -16,9 +16,9 @@ import (
 // The command has the following structure:
 //
 // 	ssh
-// 	  environment 	# develop
+// 	    environment 	# develop
 // 		group		# publishing_mount
-//		  instance	# 1
+//		    instance	# 1
 //
 func sshCommand(cfg *config.Config) (*cobra.Command, error) {
 	sshC := &cobra.Command{
@@ -65,7 +65,7 @@ func createEnvironmentSubCommands(cfg *config.Config, portArgs *[]string, verbos
 func createEnvironmentGroupSubCommands(env config.Environment, cfg *config.Config, portArgs *[]string, verboseCount *int) ([]*cobra.Command, error) {
 	groups, err := ansible.GetGroupsForEnvironment(cfg.DPSetupPath, env.Name)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "error loading ansible hosts for %s\n", env.Name)
+		return nil, errors.WithMessagef(err, "error loading ansible hosts for %s", env.Name)
 	}
 
 	commands := make([]*cobra.Command, 0)

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -17,14 +17,14 @@ import (
 // Launch an ssh connection to the specified environment
 func Launch(cfg *config.Config, env config.Environment, instance aws.EC2Result, portArgs *[]string, verboseCount *int) error {
 	if len(cfg.SSHUser) == 0 {
-		out.Highlight(out.WARN, "no %s is defined in your configuration file you can view the app configuration values using the %s command\n", "ssh user", "spew config")
-		return errors.New("missing ssh user in config file")
+		out.Highlight(out.WARN, "no %s is defined in your configuration file you can view the app configuration values using the %s command", "ssh user", "spew config")
+		return errors.New("missing `ssh user` in config file")
 	}
 
 	lvl := out.GetLevel(env)
 	fmt.Println("")
 	out.Highlight(lvl, "Launching SSH connection to %s", env.Name)
-	out.Highlight(lvl, "[IP: %s | Name: %s | Groups %s]\n", instance.IPAddress, instance.Name, instance.AnsibleGroups)
+	out.Highlight(lvl, "[IP: %s | Name: %s | Groups %s]", instance.IPAddress, instance.Name, instance.AnsibleGroups)
 
 	pwd := filepath.Join(cfg.DPSetupPath, "ansible")
 	args := []string{"-F", "ssh.cfg"}


### PR DESCRIPTION
- `remote allow` now does `deny` first (new `--no-deny` flag retains old behaviour/IPs)
- tidy up some `out` strings (mostly superfluous newlines)