### PR TITLE
Enable running of dp without SSH setup

### DIFF
--- a/command/root_command.go
+++ b/command/root_command.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-cli/config"
+	"github.com/ONSdigital/dp-cli/out"
 	"github.com/spf13/cobra"
 )
 
@@ -63,9 +64,10 @@ func getSubCommands(cfg *config.Config) ([]*cobra.Command, error) {
 
 	ssh, err := sshCommand(cfg)
 	if err != nil {
-		return nil, err
+		out.WarnFHighlight("warning: failed to initialise ssh subcommands: %s", err)
+	} else {
+		subCommands = append(subCommands, ssh)
 	}
 
-	subCommands = append(subCommands, ssh)
 	return subCommands, nil
 }


### PR DESCRIPTION
If the user does not have access to dp-setup the cli would previously
fail, blocking use of any of the other features of the tool. By changing
this error to warning we enable a wider range of users who may not have
the dp-setup repo cloned to still use the other subcommands.