### PR TITLE
Allow repo paths to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# dp-cli
+dp-cli
+======
 
 Command-line client providing *handy helper tools* for the ONS Digital Publishing software engineering team
 
 :warning: Still in active development. If you notice any bugs/issues please open a Github issue.
 
-### Getting started
+Getting started
+---------------
 
 Clone the code
 
@@ -14,66 +16,47 @@ git clone git@github.com:ONSdigital/dp-cli.git
 
 :warning: `dp-cli` uses Go Modules and **must** be cloned to a location outside of your `$GOPATH`.
 
-#### Prerequisites
+### Prerequisites
 
-`dp-cli` uses Go Modules so requires a go version of **1.11** or later.
+**Required:**
 
-`dp-cli` requires (for some functionality) the repos:
+The DP CLI uses Go Modules so requires a go version of **1.11** or later.
 
-- `dp-code-list-scripts`
-- `dp-hierarchy-builder`
+**Optional:**
 
-to be on your `$GOPATH`:
+ The following are only required for some functionality of this tool.
 
-```sh
-go get github.com/ONSdigital/dp-code-list-scripts
-go get github.com/ONSdigital/dp-hierarchy-builder
-```
+In order to use the `dp ssh` subcommand you will need:
 
-`dp-cli` also depends on `dp-setup` for  environment config:
+- [`dp-setup`](https://github.com/ONSdigital/dp-setup) cloned locally:
 
-```sh
-git clone git@github.com:ONSdigital/dp-setup.git
-```
+  ```bash
+  git clone git@github.com:ONSdigital/dp-setup
+  ```
+
+In order to use the `dp import cmd` subcommand you will need:
+
+- [`dp-code-list-scripts`](https://github.com/ONSdigital/dp-code-list-scripts) cloned locally:
+
+  ```bash
+  git clone git@github.com:ONSdigital/dp-code-list-scripts
+  ```
+
+- [`dp-hierarchy-builder`](https://github.com/ONSdigital/dp-hierarchy-builder) cloned locally:
+
+  ```bash
+  git clone git@github.com:ONSdigital/dp-hierarchy-builder
+  ```
 
 ### Configuration
 
-`dp-cli` configuration is defined in a YAML file and the CLI expects an environment variable `DP_CLI_CONFIG` with the path to that config file.
+Configuration is defined in a YAML file. By default the CLI expects the config to be in `~/.dp-cli-config.yml`. The config file location can be customised by setting `DP_CLI_CONFIG` environment variable to your chosen path.
 
-Create a new `dp-cli-config.yml` file and add the example content below (edit to match your local setup):
+The [sample config file](./config/example_config.yml) should be tailored to suit you. For example:
 
-```yaml
-## Example config file - replace fields as required
-dp-setup-path: "/path/to/your/clone/of/dp-setup" # The path to the dp-setup repo on your machine
-cmd:
-  neo4j-url: bolt://localhost:7687
-  mongo-url: localhost:27017
-  mongo-dbs:  # The mongo databases to be dropped when cleaning your data
-    - "imports"
-    - "datasets"
-    - "filters"
-    - "codelists"
-    - "test"
-  hierarchies: # The hierarchies import scripts to run when importing data
-    - "admin-geography.cypher"
-    - "cpih1dim1aggid.cypher"
-
-  codelists: # The codelist import scripts to run when importing data
-    - "opss.yaml"
-ssh-user: JamesHetfield
-environments:
-  - name: production
-    profile: production
-  - name: develop
-    profile: development
-  - name: cmd-dev
-    profile: development
-```
-
-Create an environment variable `DP_CLI_CONFIG` with the path to the above file:
-
-```sh
-export DP_CLI_CONFIG="<YOUR_PATH>/dp-cli-config.yml"
+```bash
+cp -i config/example_config.yml ~/.dp-cli-config.yml
+vi ~/.dp-cli-config.yml
 ```
 
 ### Build and run
@@ -127,7 +110,7 @@ Use the available commands for more info on the functionality available.
 
 [Ensure you have AWS credentials set up](https://github.com/ONSdigital/dp/blob/master/guides/AWS_CREDENTIALS.md).
 
-If you do not want to set up separate profiles, another option is to not specify any profiles in your `dp-cli-config.yml`. That way the default credentials will be used.
+If you do not want to set up separate profiles, another option is to not specify any profiles in your `~/.dp-cli-config.yml`. That way the default credentials will be used.
 
 ```yaml
 environments:

--- a/command/import_data.go
+++ b/command/import_data.go
@@ -19,12 +19,12 @@ func importDataSubCommand(cfg *config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			err = customisemydata.ImportGenericHierarchies(hierarchyBuilderPath, cfg)
+			err = customisemydata.ImportGenericHierarchies(cfg)
 			if err != nil {
 				return err
 			}
 
-			err = customisemydata.ImportCodeLists(codeListScriptsPath, cfg)
+			err = customisemydata.ImportCodeLists(cfg)
 			if err != nil {
 				return err
 			}
@@ -44,12 +44,12 @@ func initCustomiseMyData(cfg *config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			err = customisemydata.ImportGenericHierarchies(hierarchyBuilderPath, cfg)
+			err = customisemydata.ImportGenericHierarchies(cfg)
 			if err != nil {
 				return err
 			}
 
-			err = customisemydata.ImportCodeLists(codeListScriptsPath, cfg)
+			err = customisemydata.ImportCodeLists(cfg)
 			if err != nil {
 				return err
 			}

--- a/command/root_command.go
+++ b/command/root_command.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"math/rand"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/ONSdigital/dp-cli/config"
@@ -14,7 +12,6 @@ var (
 	root *cobra.Command
 
 	r                    *rand.Rand
-	goPath               string
 	onsDigitalPath       string
 	hierarchyBuilderPath string
 	codeListScriptsPath  string
@@ -25,14 +22,6 @@ var (
 func Load(cfg *config.Config) (*cobra.Command, error) {
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r = rand.New(s1)
-
-	goPath = os.Getenv("GOPATH")
-
-	onsDigitalPath = filepath.Join(goPath, "src/github.com/ONSdigital")
-
-	hierarchyBuilderPath = filepath.Join(onsDigitalPath, "dp-hierarchy-builder/cypher-scripts")
-
-	codeListScriptsPath = filepath.Join(onsDigitalPath, "dp-code-list-scripts/code-list-scripts")
 
 	root = &cobra.Command{
 		Use:   "dp",

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ONSdigital/dp-cli/ansible"
 	"github.com/ONSdigital/dp-cli/aws"
 	"github.com/ONSdigital/dp-cli/config"
+	"github.com/ONSdigital/dp-cli/out"
 	"github.com/ONSdigital/dp-cli/ssh"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func sshCommand(cfg *config.Config) (*cobra.Command, error) {
 		return nil, err
 	}
 	if len(environmentCommands) == 0 {
-		fmt.Println("Warning: No subcommands found for envs - missing envs in config?")
+		out.Warn("Warning: No subcommands found for envs - missing envs in config?")
 	}
 
 	sshC.AddCommand(environmentCommands...)

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -1,22 +1,26 @@
 ##
 ## Example config file Replace fields as required
 ##
-dp-setup-path: "path/to/your/dp-setup/project" # The path to the dp-setup repo on your machine.
+dp-setup-path: "path/to/your/dp-setup" # The path to the dp-setup repo on your machine.
+dp-hierarchy-builder-path: "path/to/your/dp-hierarchy-builder" # The path to the dp-hierarchy-builder repo on your machine.
+dp-code-list-scripts-path: "path/to/your/dp-code-list-scripts" # The path to the dp-code-list-scripts repo on your machine.
 cmd:
   neo4j-url: bolt://localhost:7687
   mongo-url: localhost:27017
-  mongo-dbs:  # The mongo databases to be dropped when cleaning your CMD data
+  mongo-dbs: # The mongo databases to be dropped when cleaning your CMD data
     - "imports"
     - "datasets"
     - "filters"
     - "codelists"
     - "test"
-  hierarchies: # The hierarchies import scripts to run when importing CMD data.
+  hierarchies: # The hierarchies import scripts to run when importing CMD data
     - "admin-geography.cypher"
     - "cpih1dim1aggid.cypher"
+    - "mid-year-pop-geography.cypher"
 
-  codelists: # The CMD codelist import scripts to run when importing CMD data.
-    - "opss.yaml"
+  codelists: # The codelist import scripts to run when importing CMD data
+    - "cpih.yaml"
+    - "mid-year-pop-est.yaml"
 ssh-user: JamesHetfield
 environments:
   - name: production

--- a/customisemydata/neo4j.go
+++ b/customisemydata/neo4j.go
@@ -2,6 +2,7 @@ package customisemydata
 
 import (
 	"fmt"
+
 	"github.com/ONSdigital/dp-cli/cli"
 	"github.com/ONSdigital/dp-cli/config"
 	"github.com/ONSdigital/dp-cli/out"
@@ -32,7 +33,7 @@ func DropNeo4jData(cfg *config.Config) error {
 	return nil
 }
 
-func ImportGenericHierarchies(hierarchyBuilderPath string, cfg *config.Config) error {
+func ImportGenericHierarchies(cfg *config.Config) error {
 	if len(cfg.CMD.Hierarchies) == 0 {
 		out.Info("no hierarchies defined in config skipping step")
 		return nil
@@ -44,7 +45,7 @@ func ImportGenericHierarchies(hierarchyBuilderPath string, cfg *config.Config) e
 	go progressTicker()
 
 	for _, script := range cfg.CMD.Hierarchies {
-		command := fmt.Sprintf("cypher-shell < %s/%s", hierarchyBuilderPath, script)
+		command := fmt.Sprintf("cypher-shell < %s/%s", cfg.DPHierarchyBuilderPath, script)
 
 		if err := cli.ExecCommand(command, ""); err != nil {
 			stopC <- true
@@ -58,7 +59,7 @@ func ImportGenericHierarchies(hierarchyBuilderPath string, cfg *config.Config) e
 	return nil
 }
 
-func ImportCodeLists(codeListScriptsPath string, cfg *config.Config) error {
+func ImportCodeLists(cfg *config.Config) error {
 	if len(cfg.CMD.Codelists) == 0 {
 		out.Info("no code lists defined in config skipping step")
 		return nil
@@ -72,7 +73,7 @@ func ImportCodeLists(codeListScriptsPath string, cfg *config.Config) error {
 	for _, codelist := range cfg.CMD.Codelists {
 		command := fmt.Sprintf("./load -q=%s -f=%s", "cypher", codelist)
 
-		if err := cli.ExecCommand(command, codeListScriptsPath); err != nil {
+		if err := cli.ExecCommand(command, cfg.DPCodeListScriptsPath); err != nil {
 			stopC <- true
 			return err
 		}


### PR DESCRIPTION
Allow the user to customise where the dp-hierarchy-api and
dp-code-list-scripts repos are checked out. This is mostly to support
the fact that these repos will need to move outside the GOPATH in order
to work for modules. Prior to this change these repos would have to be
checked out twice.

One drawback to this change is that everyone will need to add the two new configs, however I was hesitant to add the existing paths under the GOPATH as a default as this would perpetuate the double clone situation. A clean break feels like the way to go in this case.