### PR TITLE
remove access to port 80 for Publishing SG, allow config to add back in

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -115,24 +115,24 @@ func getNamedSG(name, environment, profile, sshUser string, ports []int64) (sg s
 	return
 }
 
-func getBastionSGForEnvironment(environment, profile, sshUser string, morePorts []int64) (secGroup, error) {
+func getBastionSGForEnvironment(environment, profile, sshUser string, extraPorts []int64) (secGroup, error) {
 	return getNamedSG(
 		environment+" - bastion", environment, profile, sshUser,
-		append(morePorts, 22, 443),
+		append(extraPorts, 22, 443),
 	)
 }
 
-func getELBPublishingSGForEnvironment(environment, profile, sshUser string, morePorts []int64) (secGroup, error) {
+func getELBPublishingSGForEnvironment(environment, profile, sshUser string, extraPorts []int64) (secGroup, error) {
 	return getNamedSG(
 		environment+" - publishing elb", environment, profile, sshUser,
-		append(morePorts, 443),
+		append(extraPorts, 443),
 	)
 }
 
-func getELBWebSGForEnvironment(environment, profile, sshUser string, morePorts []int64) (secGroup, error) {
+func getELBWebSGForEnvironment(environment, profile, sshUser string, extraPorts []int64) (secGroup, error) {
 	return getNamedSG(
 		environment+" - web elb", environment, profile, sshUser,
-		append(morePorts, 80, 443),
+		append(extraPorts, 80, 443),
 	)
 }
 
@@ -141,16 +141,16 @@ func getConcourseWebSG(sshUser string) (secGroup, error) {
 }
 
 // AllowIPForEnvironment adds your IP to this environment
-func AllowIPForEnvironment(sshUser, environment, profile string, morePorts config.AddPorts) error {
-	return changeIPsForEnvironment(true, sshUser, environment, profile, morePorts)
+func AllowIPForEnvironment(sshUser, environment, profile string, extraPorts config.ExtraPorts) error {
+	return changeIPsForEnvironment(true, sshUser, environment, profile, extraPorts)
 }
 
 // DenyIPForEnvironment removes your IP - and any others for sshUser - for this environment
-func DenyIPForEnvironment(sshUser, environment, profile string, morePorts config.AddPorts) error {
-	return changeIPsForEnvironment(false, sshUser, environment, profile, morePorts)
+func DenyIPForEnvironment(sshUser, environment, profile string, extraPorts config.ExtraPorts) error {
+	return changeIPsForEnvironment(false, sshUser, environment, profile, extraPorts)
 }
 
-func changeIPsForEnvironment(isAllow bool, sshUser, environment, profile string, morePorts config.AddPorts) (err error) {
+func changeIPsForEnvironment(isAllow bool, sshUser, environment, profile string, extraPorts config.ExtraPorts) (err error) {
 	if len(sshUser) == 0 {
 		return errors.New("please set DP_SSH_USER to change remote access")
 	}
@@ -178,18 +178,18 @@ func changeIPsForEnvironment(isAllow bool, sshUser, environment, profile string,
 
 	} else {
 		ec2Svc = getEC2Service(environment, profile)
-		if sg, err = getBastionSGForEnvironment(environment, profile, sshUser, morePorts.Bastion); err != nil {
+		if sg, err = getBastionSGForEnvironment(environment, profile, sshUser, extraPorts.Bastion); err != nil {
 			return err
 		}
 		secGroups = append(secGroups, sg)
 
 		if environment != "production" {
-			if sg, err = getELBPublishingSGForEnvironment(environment, profile, sshUser, morePorts.Publishing); err != nil {
+			if sg, err = getELBPublishingSGForEnvironment(environment, profile, sshUser, extraPorts.Publishing); err != nil {
 				return err
 			}
 			secGroups = append(secGroups, sg)
 
-			if sg, err = getELBWebSGForEnvironment(environment, profile, sshUser, morePorts.Web); err != nil {
+			if sg, err = getELBWebSGForEnvironment(environment, profile, sshUser, extraPorts.Web); err != nil {
 				return err
 			}
 			secGroups = append(secGroups, sg)

--- a/command/remote_access.go
+++ b/command/remote_access.go
@@ -47,10 +47,10 @@ func allowCommand(sshUser string, envs []config.Environment) *cobra.Command {
 				lvl := out.GetLevel(env)
 				if !*skipDeny {
 					out.Highlight(lvl, "removing existing access to %s", env.Name)
-					aws.DenyIPForEnvironment(sshUser, env.Name, env.Profile)
+					aws.DenyIPForEnvironment(sshUser, env.Name, env.Profile, env.ExtraPorts)
 				}
 				out.Highlight(lvl, "allowing access to %s", env.Name)
-				return aws.AllowIPForEnvironment(sshUser, env.Name, env.Profile)
+				return aws.AllowIPForEnvironment(sshUser, env.Name, env.Profile, env.ExtraPorts)
 			},
 		})
 	}
@@ -76,7 +76,7 @@ func denyCommand(sshUser string, envs []config.Environment) *cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				lvl := out.GetLevel(env)
 				out.Highlight(lvl, "denying access to %s", env.Name)
-				return aws.DenyIPForEnvironment(sshUser, env.Name, env.Profile)
+				return aws.DenyIPForEnvironment(sshUser, env.Name, env.Profile, env.ExtraPorts)
 			},
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -38,10 +38,19 @@ type CMD struct {
 
 // Environment represents an environment
 type Environment struct {
-	Name    string `yaml:"name"`
-	Profile string `yaml:"profile"`
+	Name       string   `yaml:"name"`
+	Profile    string   `yaml:"profile"`
+	ExtraPorts AddPorts `yaml:"extra-ports"`
 }
 
+// AddPorts is a list of ports for the given Security Group
+type AddPorts struct {
+	Bastion    []int64 `yaml:"bastion"`
+	Publishing []int64 `yaml:"publishing"`
+	Web        []int64 `yaml:"web"`
+}
+
+// Get returns the config struct by parsing the YML file
 func Get() (*Config, error) {
 	path := os.Getenv("DP_CLI_CONFIG")
 	if len(path) == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -38,13 +38,13 @@ type CMD struct {
 
 // Environment represents an environment
 type Environment struct {
-	Name       string   `yaml:"name"`
-	Profile    string   `yaml:"profile"`
-	ExtraPorts AddPorts `yaml:"extra-ports"`
+	Name       string     `yaml:"name"`
+	Profile    string     `yaml:"profile"`
+	ExtraPorts ExtraPorts `yaml:"extra-ports"`
 }
 
-// AddPorts is a list of ports for the given Security Group
-type AddPorts struct {
+// ExtraPorts is a list of ports for the given Security Group
+type ExtraPorts struct {
 	Bastion    []int64 `yaml:"bastion"`
 	Publishing []int64 `yaml:"publishing"`
 	Web        []int64 `yaml:"web"`


### PR DESCRIPTION
sample config, to restore old behaviour:

```
environments:
  - name: cmd-dev
      extra-ports:
          publishing:
              - 80
```