### PR TITLE
Resolve path, unused import and test errors when creating an API

### DIFF
--- a/project_generation/content/templates/api/api/api.go.tmpl
+++ b/project_generation/content/templates/api/api/api.go.tmpl
@@ -18,6 +18,7 @@ func Setup(ctx context.Context, r *mux.Router) *API {
 		Router: r,
 	}
 
+	log.Event(ctx, "remove hello endpoint")
 	r.HandleFunc("/hello", HelloHandler()).Methods("GET")
 	return api
 }

--- a/project_generation/content/templates/api/api/api.go.tmpl
+++ b/project_generation/content/templates/api/api/api.go.tmpl
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 
-	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 )
 
@@ -18,7 +17,6 @@ func Setup(ctx context.Context, r *mux.Router) *API {
 		Router: r,
 	}
 
-	log.Event(ctx, "remove hello endpoint", log.INFO)
 	r.HandleFunc("/hello", HelloHandler()).Methods("GET")
 	return api
 }

--- a/project_generation/content/templates/api/api/api.go.tmpl
+++ b/project_generation/content/templates/api/api/api.go.tmpl
@@ -18,7 +18,7 @@ func Setup(ctx context.Context, r *mux.Router) *API {
 		Router: r,
 	}
 
-	log.Event(ctx, "remove hello endpoint")
+	log.Event(ctx, "remove hello endpoint", log.INFO)
 	r.HandleFunc("/hello", HelloHandler()).Methods("GET")
 	return api
 }

--- a/project_generation/content/templates/api/api/hello.go.tmpl
+++ b/project_generation/content/templates/api/api/hello.go.tmpl
@@ -15,6 +15,7 @@ type HelloResponse struct {
 
 // HelloHandler returns function containing a simple hello world example of an api handler
 func HelloHandler() http.HandlerFunc {
+	log.Event(ctx, "api contains example endpoint, remove hello.go as soon as possible", log.INFO)
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 

--- a/project_generation/content/templates/api/service/service_test.go.tmpl
+++ b/project_generation/content/templates/api/service/service_test.go.tmpl
@@ -119,7 +119,7 @@ func TestRun(t *testing.T) {
 			Convey("The checkers are registered and the healthcheck and http server started", func() {
 				So(len(hcMock.AddCheckCalls()), ShouldEqual, 0)
 				So(len(initMock.DoGetHTTPServerCalls()), ShouldEqual, 1)
-				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, "localhost:25300")
+				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, "localhost:{{.Port}}")
 				So(len(hcMock.StartCalls()), ShouldEqual, 1)
 				//!!! a call needed to stop the server, maybe ?
 				serverWg.Wait() // Wait for HTTP server go-routine to finish

--- a/project_generation/content/templates/base-app/config/config.go.tmpl
+++ b/project_generation/content/templates/base-app/config/config.go.tmpl
@@ -24,7 +24,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		BindAddr:                   ":{{.Port}}",
+		BindAddr:                   "localhost:{{.Port}}",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/project_generation/content/templates/base-app/config/config_test.go.tmpl
+++ b/project_generation/content/templates/base-app/config/config_test.go.tmpl
@@ -24,8 +24,8 @@ func TestConfig(t *testing.T) {
 				configuration, err = Get() // This Get() is only called once, when inside this function
 				So(err, ShouldBeNil)
 				So(configuration, ShouldResemble, &Config{
-					BindAddr:                   "localhost:25300",
-					GracefulShutdownTimeout:    10 * time.Second,
+					BindAddr:                   "localhost:{{.Port}}",
+					GracefulShutdownTimeout:    5 * time.Second,
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
 				})

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -146,7 +146,7 @@ func (a application) createAPIContentDirectoryStructure() error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(filepath.Join(a.pathToRepo, "service"), os.ModePerm)
+	err = os.MkdirAll(filepath.Join(a.pathToRepo, "service/mock"), os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix errors seen when running ```dp generate-project```, to generate an API where `make test` pass and `make debug` runs

- Create a path for the mock file
- Use an unused import
- Update the service_test and config_test to use a port variable
- Update the config file to have localhost