### PR TITLE
Fix ansible groups parsing after ansible upgrade

### DIFF
--- a/ansible/groups.go
+++ b/ansible/groups.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	groupPrefix    = "["
-	groupSeparator = ":"
 	groupSuffix    = "]"
 )
 
@@ -48,7 +47,7 @@ func parseFile(fileBytes []byte) ([]string, error) {
 		s = strings.TrimSpace(s)
 
 		if isGroupLine(s) {
-			name := s[1:strings.Index(s, groupSeparator)]
+			name := s[1:len(s)-1]
 			groups = append(groups, name)
 		}
 	}
@@ -57,5 +56,5 @@ func parseFile(fileBytes []byte) ([]string, error) {
 }
 
 func isGroupLine(s string) bool {
-	return strings.HasPrefix(s, groupPrefix) && strings.Contains(s, groupSeparator) && strings.HasSuffix(s, groupSuffix)
+	return strings.HasPrefix(s, groupPrefix) && strings.HasSuffix(s, groupSuffix)
 }


### PR DESCRIPTION
During the upgrade to ansible 2.10 the groups in the `hosts` file were
changed. Long term it might be best to change the way we are getting the
groups or even included them within this repo, but in the meantime the
parsing has been updated to work with the latest ansible inventory.