### PR TITLE
Add health endpoint into swagger spec template for API generation tool

### DIFF
--- a/project_generation/content/templates/api/swagger.yaml.tmpl
+++ b/project_generation/content/templates/api/swagger.yaml.tmpl
@@ -11,7 +11,7 @@ schemes:
   - http
 tags:
   - name: "hello"
-  - name: "Private"
+  - name: "private"
 paths:
   /hello:
     get:
@@ -32,7 +32,7 @@ paths:
   /health:
     get:
       tags:
-        - Private
+        - private
       summary: "Returns API's health status"
       description: "Returns health status of the API and checks on dependent services"
       produces:

--- a/project_generation/content/templates/api/swagger.yaml.tmpl
+++ b/project_generation/content/templates/api/swagger.yaml.tmpl
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  title: {{.Name}}
+  title: "{{.Name}}"
   description: "{{.Description}}"
   version: 1.0.0
   license:
@@ -11,6 +11,7 @@ schemes:
   - http
 tags:
   - name: "hello"
+  - name: "Private"
 paths:
   /hello:
     get:
@@ -28,6 +29,24 @@ paths:
         500:
           $ref: '#/responses/InternalError'
 
+  /health:
+    get:
+      tags:
+        - Private
+      summary: "Returns API's health status"
+      description: "Returns health status of the API and checks on dependent services"
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully returns OK status with checks of dependent services"
+          schema:
+            $ref: "#/definitions/Health"
+        429:
+          description: "Services warming up or degraded (at least one check in WARNING or CRITICAL status)"
+        500:
+          $ref: "#/responses/InternalError"
+
 responses:
   InternalError:
     description: "Failed to process the request due to an internal error"
@@ -40,3 +59,72 @@ definitions:
         type: string
         description: "Message returned by hello world endpoint"
         example: "Hello, world!"
+  Health:
+    type: object
+    properties:
+      status:
+        type: string
+        description: "The status of the API"
+        enum: ["OK", "WARNING", "CRITICAL"]
+      version:
+        type: object
+        properties:
+          build_time:
+            type: string
+            description: "The build date and time of the API"
+            example: "2020-06-11T12:49:20+01:00"
+          git_commit:
+            type: string
+            description: "The git commit hash of the API"
+            example: "7c2febbf2b818175112478d4ffbadbee1b654f63"
+          language:
+            type: string
+            description: "The programming language used to implement API"
+            example: "go"
+          language_version:
+            type: string
+            description: "The version of the programming language used to implement API"
+            example: "go1.14.3"
+          version:
+            type: string
+            description: "The version of API"
+            example: "1.0.0"
+      uptime:
+        type: string
+        description: "The uptime of API"
+        example: "34516"
+      start_time:
+        type: string
+        description: "The start date and time of API running"
+        example: "2020-06-11T11:49:21.520922Z"
+      checks:
+        type: array
+        items:
+          $ref: '#/definitions/HealthChecker'
+  HealthChecker:
+    type: object
+    properties:
+      name:
+        type: string
+        description: "The name of external service used by API"
+        enum: ["mongodb"]
+      status:
+        type: string
+        description: "The status of the external service"
+        enum: ["OK", "WARNING", "CRITICAL"]
+      message:
+        type: string
+        description: "The message status of the external service"
+        example: "mongodb is OK"
+      last_checked:
+        type: string
+        description: "The last health check date and time of the external service"
+        example: "2020-06-11T11:49:50.330089Z"
+      last_success:
+        type: string
+        description: "The last successful health check date and time of the external service"
+        example: "2020-06-11T11:49:50.330089Z"
+      last_failure:
+        type: string
+        description: "The last failed health check date and time of the external service"
+        example: "20219-09-22T11:48:51.0000001Z"

--- a/project_generation/content/templates/api/swagger.yaml.tmpl
+++ b/project_generation/content/templates/api/swagger.yaml.tmpl
@@ -127,4 +127,4 @@ definitions:
       last_failure:
         type: string
         description: "The last failed health check date and time of the external service"
-        example: "20219-09-22T11:48:51.0000001Z"
+        example: "2019-09-22T11:48:51.0000001Z"


### PR DESCRIPTION
### What has changed

Extend the API swagger spec template to include health endpoint.

This will allow developers to inherit the correct spec for health endpoint when generating a new repo that contains an API service.

### How to review

Use the [Swagger Editor](https://editor.swagger.io/) to view API generation template for swagger spec
Make sure the spec abides by [dp healthcheck standards doc](https://github.com/ONSdigital/dp/blob/main/standards/HEALTH_CHECK_SPECIFICATION.md)

### Who can review

Anyone