### PR TITLE
add ability to ssh by IP: `dp ssh $env 10.1.2.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-dp-cli
-======
+# dp-cli
 
 Command-line client providing *handy helper tools* for the ONS Digital Publishing software engineering team
 
 :warning: Still in active development. If you notice any bugs/issues please open a Github issue.
 
-Getting started
----------------
+## Getting started
 
 Clone the code
 
@@ -84,16 +82,21 @@ vi ~/.dp-cli-config.yml
 
 [ set paths for:
 
+```yaml
     dp-setup-path:
     dp-hierarchy-builder-path:
     dp-code-list-scripts-path:
 
    set your `ssh-user:`
+```
 
 and if this is a first time setup, comment out production from environments, thus:
 
+```yaml
     # - name: production
     #   profile: production
+```
+
 ]
 
 ### Build and run
@@ -104,15 +107,17 @@ Build, install and start the CLI:
 make install
 dp
 ```
+
 [
   If you get:
 
   `zsh: command not found: dp`
 
 Then either edit your .zshrc file have the correct path OR do:
-  ```sh
-  echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.zshrc
-  ```
+
+```sh
+echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.zshrc
+```
 
   and restart the terminal ]
 
@@ -210,12 +215,15 @@ You can run ssh commands from the command-line, for example to determine the tim
 
 ```sh
 $ dp ssh develop web 1 date
+[...motd banner...]
+[result of date command]
 ```
 
 :warning: However, if you wish to include *flags* in the (remote) command, you must tell `dp` to stop looking for flags - use the `--` flag:
 
 ```sh
 $ dp ssh develop web 1 -- ls -la
+[...]
 ```
 
 #### Manually configuring your IP

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -24,7 +24,7 @@ func Launch(cfg *config.Config, env config.Environment, instance aws.EC2Result, 
 	lvl := out.GetLevel(env)
 	fmt.Println("")
 	out.Highlight(lvl, "Launching SSH connection to %s", env.Name)
-	out.Highlight(lvl, "[IP: %s | Name: %s | Groups %s]", instance.IPAddress, instance.Name, instance.AnsibleGroups)
+	out.Highlight(lvl, "[IP: %s | Name: %s | Groups %s | AKA %s", instance.IPAddress, instance.Name, instance.AnsibleGroups, strings.Join(instance.GroupAKA, ", "))
 
 	ansibleDir := filepath.Join(cfg.DPSetupPath, "ansible")
 	args := []string{"-F", "ssh.cfg"}


### PR DESCRIPTION
I found looking up an IP (from an alert, say) to find out which host it was was slowing me down in getting on to the box and fixing :all_the_things:
so this PR let's us just use:

- `dp ssh $env $ip` to get there quickly
- `dp ssh $env` also informs you which host(s) IPs refer to, if you prefer just to look it up