### PR TITLE
Improve validation of project type

### DIFF
--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -366,7 +366,7 @@ func OptionPromptInput(ctx context.Context, prompt string, options ...string) (s
 			log.Event(ctx, "failed to convert user input to valid option", log.Error(err))
 			return "", scanner.Err()
 		}
-		if optionSelected > len(options) || optionSelected < 0 {
+		if optionSelected > len(options)-1 || optionSelected < 0 {
 			fmt.Println("\n selected option is not valid, please select from the range provided")
 		} else {
 			return options[optionSelected], nil

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -129,13 +129,19 @@ func ValidateAppDescription(ctx context.Context, description string) (string, er
 
 // ValidateProjectType will ensure that the project type provided by the users is one that can be boilerplate
 func ValidateProjectType(ctx context.Context, projectType string) (validatedProjectType string, err error) {
-	if projectType == "" {
-		prompt := "Please specify the project type"
-		options := []string{"generic-project", "base-application", "api", "controller", "event-driven", "library"}
-		projectType, err = OptionPromptInput(ctx, prompt, options...)
-		if err != nil {
-			return "", err
+	options := []string{"generic-project", "base-application", "api", "controller", "event-driven", "library"}
+
+	if projectType != "" {
+		for _, option := range options {
+			if projectType == option {
+				return projectType, err
+			}
 		}
+	}
+	prompt := "Please specify the project type"
+	projectType, err = OptionPromptInput(ctx, prompt, options...)
+	if err != nil {
+		return "", err
 	}
 	return projectType, err
 }

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -362,11 +362,8 @@ func OptionPromptInput(ctx context.Context, prompt string, options ...string) (s
 		}
 
 		optionSelected, err := strconv.Atoi(input)
-		if scanner.Err() != nil {
-			log.Event(ctx, "failed to convert user input to valid option", log.Error(err))
-			return "", scanner.Err()
-		}
-		if optionSelected > len(options)-1 || optionSelected < 0 {
+
+		if err != nil || optionSelected > len(options)-1 || optionSelected < 0 {
 			fmt.Println("\n selected option is not valid, please select from the range provided")
 		} else {
 			return options[optionSelected], nil


### PR DESCRIPTION
### What
When the user ran the `generate-project` using command line parameters with an invalid value as the project type, there was no validation or warning resulting in panic runtime errors further down the line. This is now solved by validating the parameter against the list of valid values.

Additionally, when the user chose to use prompts instead of command line parameters, there was no numeric validation, resulting in a 0 (generic-project) being selected when inputting any word different to the valid values.
Also, in this scenario a 6 was accepted only to result in an `index out of range` error because of a bug in the index comparison.

### How to review

Run the `dp generate-project` command using valid and invalid project types both in command line and using prompts.

Examples: 
- `dp generate-project --create-repository yes --name pr-review --description "Reviewing PR" --type other `
- `dp generate-project --create-repository yes --name pr-review --description "Reviewing PR" --type library`
- `dp generate-project --create-repository yes --name pr-review --description "Reviewing PR" --type 6 `
- `dp generate-project --create-repository yes --name pr-review --description "Reviewing PR"`  <-- use prompts to provide `other`, `library` and `6`

### Who can review

Anyone
