### PR TITLE
Fix tests in project generation for controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dp-cli-config.yml
 dp-cli
 dp
 vendor/
+
+# Mac
+.DS_Store

--- a/project_generation/content/templates/controller/config/config.go.tmpl
+++ b/project_generation/content/templates/controller/config/config.go.tmpl
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 // TODO: remove hello world example config option
@@ -24,7 +25,7 @@ func Get() (*Config, error) {
 		return cfg, nil
 	}
 
-	cfg := &Config{
+	cfg = &Config{
 		BindAddr:                   ":{{.Port}}",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,

--- a/project_generation/content/templates/controller/config/config_test.go.tmpl
+++ b/project_generation/content/templates/controller/config/config_test.go.tmpl
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestConfig(t *testing.T) {
+	os.Clearenv()
+	var err error
+	var configuration *Config
+	
+	Convey("Given an environment with no environment variables set", t, func() {
+		Convey("Then cfg should be nil", func() {
+			So(cfg, ShouldBeNil)
+		})
+
+		Convey("When the config values are retrieved", func() {
+
+			Convey("Then there should be no error returned, and values are as expected", func() {
+				configuration, err = Get() // This Get() is only called once, when inside this function
+				So(err, ShouldBeNil)
+				So(configuration, ShouldResemble, &Config{
+					BindAddr:                   ":{{.Port}}",
+					GracefulShutdownTimeout:    5 * time.Second,
+					HealthCheckInterval:        30 * time.Second,
+					HealthCheckCriticalTimeout: 90 * time.Second,
+					HelloWorldEmphasise:        true,
+				})
+			})
+
+			Convey("Then a second call to config should return the same config", func() {
+				// This achieves code coverage of the first return in the Get() function.
+				newCfg, newErr := Get()
+				So(newErr, ShouldBeNil)
+				So(newCfg, ShouldResemble, cfg)
+			})
+		})
+	})
+}

--- a/project_generation/content/templates/controller/mapper/mapper_test.go.tmpl
+++ b/project_generation/content/templates/controller/mapper/mapper_test.go.tmpl
@@ -28,6 +28,6 @@ func TestUnitMapper(t *testing.T) {
 		}
 
 		hw := HelloWorld(ctx, hm, cfg)
-		So(hw, ShouldEqual, "Hello World!")
+		So(hw.HelloWho, ShouldEqual, "Hello World!")
 	})
 }

--- a/project_generation/manifest.go
+++ b/project_generation/manifest.go
@@ -218,6 +218,12 @@ var controllerFiles = []fileGen{
 		filePrefix:   "",
 	},
 	{
+		templatePath: "controller/config/config_test.go",
+		outputPath:   "config/config_test",
+		extension:    ".go",
+		filePrefix:   "",
+	},
+	{
 		templatePath: "controller/handlers/handlers.go",
 		outputPath:   "handlers/handlers",
 		extension:    ".go",


### PR DESCRIPTION
### What

The controller project created by the project generation contains tests (for config and mapper) that fail and this PR will fix them.

For the config one, it relied on the `base-app` test but the controller modifies the config template to include the `HelloWorldEmphasise` flag making that test unsuitable hence using a new version of it.

### How to review

1. `make build`
2. Create a new controller project. For example:
`./dp generate-project --type controller --create-repository no --description "pr-review" --go-version 1.17.1 --name pr-review --port 26501`
3. Go to the new project location
4. Run the tests: `make test`

### Who can review

Anyone but me
