### PR TITLE
Fix Makefile for controllers

### DIFF
--- a/project_generation/content/templates/controller/Makefile.tmpl
+++ b/project_generation/content/templates/controller/Makefile.tmpl
@@ -1,0 +1,41 @@
+BINPATH ?= build
+
+BUILD_TIME=$(shell date +%s)
+GIT_COMMIT=$(shell git rev-parse HEAD)
+VERSION ?= $(shell git tag --points-at HEAD | grep ^v | head -n 1)
+
+SERVICE_PATH = github.com/ONSdigital/{{.Name}}/service
+
+LDFLAGS = -ldflags "-X $(SERVICE_PATH).BuildTime=$(BUILD_TIME) -X $(SERVICE_PATH).GitCommit=$(GIT_COMMIT) -X $(SERVICE_PATH).Version=$(VERSION)"
+
+.PHONY: all
+all: audit test build
+
+.PHONY: audit
+audit:
+	go list -json -m all | nancy sleuth
+
+.PHONY: lint
+lint:
+	exit
+
+.PHONY: build
+build:
+	go build -tags 'production' $(LDFLAGS) -o $(BINPATH)/{{.Name}}
+
+.PHONY: debug
+debug:
+	go build -tags 'debug' $(LDFLAGS) -o $(BINPATH)/{{.Name}}
+	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/{{.Name}}
+
+.PHONY: test
+test:
+	go test -race -cover ./...
+
+.PHONY: convey
+convey:
+	goconvey ./...
+
+.PHONY: test-component
+test-component:
+	go test -cover -coverpkg=github.com/ONSdigital/{{.Name}}/... -component

--- a/project_generation/manifest.go
+++ b/project_generation/manifest.go
@@ -302,6 +302,12 @@ var controllerFiles = []fileGen{
 		filePrefix:   "",
 	},
 	{
+		templatePath: "controller/Makefile",
+		outputPath:   "Makefile",
+		extension:    "",
+		filePrefix:   "",
+	},
+	{
 		templatePath: "controller/README.md",
 		outputPath:   "README",
 		extension:    ".md",


### PR DESCRIPTION
### What

The version variables have been moved to the service package and the Makefile needs to be updated to refer to the new location

This was missed from https://github.com/ONSdigital/dp-cli/pull/97

### How to review

1. `make build`
2. Create a hello world controller:
`./dp generate-project --create-repository n --name "dp-hello-world-controller" --description "Example controller project generated by dp-cli" --go-version 1.17.1 --port 8124 --project-location . --type controller`
3. Check the generated `Makefile` is identical to the one in [dp-hello-world-controller](https://github.com/ONSdigital/dp-hello-world/blob/master/dp-hello-world-controller/Makefile)
4. Check there are no errors when running `make build` on the recently generated controller and that it starts with `make debug`

### Who can review

Anyone
