### PR TITLE
revert URL for getting IP to avoid IPv6

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ func (cfg Config) GetMyIP() (string, error) {
 	}
 
 	// use remote service to obtain IP
-	res, err := httpClient.Get("https://api64.ipify.org")
+	res, err := httpClient.Get("https://api.ipify.org")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### What

revert change to URL for getting IP address, needs to return IPv4

### How to review

`dp remote allow develop` should now work

### Who can review

Describe who worked on the changes, so that other people can review.
