### PR TITLE
Use latest go docker image for libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ Check you have a suitable version of `go` installed with:
 
 `go version`
 
-(Ideally 1.17)
+(Ideally 1.18)
 
-[ The following will ensure version 1.17
+[ The following will ensure version 1.18
 
   ```sh
-  brew install go@1.17
+  brew install go@1.18
   brew unlink go
-  brew link —force go@1.17
+  brew link —force go@1.18
   ```
 
 Check desired version of `go` is on your PATH with `echo $PATH` and if not, either edit your .zshrc file to have the correct path OR do:
 
   ```sh
   echo 'export GOPATH=$HOME/go' >> ~/.zshrc
-  echo 'export PATH="/usr/local/opt/go@1.17/bin:$PATH"' >> ~/.zshrc
+  echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.zshrc
   ```
 
   and restart the terminal ]

--- a/project_generation/content/templates/library/ci/build.yml.tmpl
+++ b/project_generation/content/templates/library/ci/build.yml.tmpl
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: {{.GoVersion}}
+    tag: latest
 
 inputs:
   - name: {{.Name}}

--- a/project_generation/content/templates/library/ci/lint.yml.tmpl
+++ b/project_generation/content/templates/library/ci/lint.yml.tmpl
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: {{.GoVersion}}
+    tag: latest
 
 inputs:
   - name: {{.Name}}

--- a/project_generation/content/templates/library/ci/scripts/audit.sh.tmpl
+++ b/project_generation/content/templates/library/ci/scripts/audit.sh.tmpl
@@ -1,7 +1,5 @@
 #!/bin/bash -eux
 
-export cwd=$(pwd)
-
-pushd $cwd/{{.Name}}
+pushd {{.Name}}
   make audit
 popd

--- a/project_generation/content/templates/library/ci/unit.yml.tmpl
+++ b/project_generation/content/templates/library/ci/unit.yml.tmpl
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: {{.GoVersion}}
+    tag: latest
 
 inputs:
   - name: {{.Name}}


### PR DESCRIPTION
### What

Libraries should be tied to latest because the dependency is defined by the app using the library instead. This ensures the library is kept up to date for an app.

Update README to refer to GO 1.18

### How to review

Sense check

### Who can review

Anyone
