### PR TITLE
Fix golang version for linter

### DIFF
--- a/project_generation/content/templates/base-app/ci/lint.yml.tmpl
+++ b/project_generation/content/templates/base-app/ci/lint.yml.tmpl
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: latest
+    tag: 1.18.3
 
 inputs:
   - name: {{.Name}}

--- a/project_generation/content/templates/library/ci/lint.yml.tmpl
+++ b/project_generation/content/templates/library/ci/lint.yml.tmpl
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: latest
+    tag: 1.18.3
 
 inputs:
   - name: {{.Name}}


### PR DESCRIPTION
### What

Fix golang version for linter to 1.18.3.

### How to review

Please check if the changes make sense

### Who can review

Anyone except me
