### PR TITLE
Fail test suite when there are pending or undefined steps

### DIFF
--- a/project_generation/content/templates/api/main_test.go.tmpl
+++ b/project_generation/content/templates/api/main_test.go.tmpl
@@ -53,6 +53,7 @@ func TestComponent(t *testing.T) {
 			Output: colors.Colored(os.Stdout),
 			Format: "pretty",
 			Paths:  flag.Args(),
+			Strict: true,
 		}
 
 		f := &ComponentTest{}

--- a/project_generation/content/templates/controller/main_test.go.tmpl
+++ b/project_generation/content/templates/controller/main_test.go.tmpl
@@ -47,6 +47,7 @@ func TestComponent(t *testing.T) {
 			Output: colors.Colored(os.Stdout),
 			Format: "pretty",
 			Paths:  flag.Args(),
+			Strict: true,
 		}
 
 		f := &ComponentTest{}

--- a/project_generation/content/templates/event/main_test.go.tmpl
+++ b/project_generation/content/templates/event/main_test.go.tmpl
@@ -48,6 +48,7 @@ func TestComponent(t *testing.T) {
 			Output: colors.Colored(os.Stdout),
 			Format: "pretty",
 			Paths:  flag.Args(),
+			Strict: true,
 		}
 
 		f := &ComponentTest{}


### PR DESCRIPTION
### What

Set Godog to strict mode, to avoid the issues described in https://github.com/ONSdigital/dp-legacy-cache-api/pull/21.

Currently, when a Godog step is missing, a warning is issued, and a step (and scenario) is marked as undefined when running the component tests. However, the exit code is still 0, which means that the pipeline will not fail when a step is undefined. This means that a malformed step could inadvertently make a whole scenario to go untested, and the Component Test pipeline job would still pass.

As part of this change, we're changing this behaviour, so that the exit code is not 0 when a step is pending or undefined.

### How to review

Ensure that the templates are not broken.

### Who can review

Anyone.
