### PR TITLE
Feature/remove go ns

### DIFF
--- a/project_generation/README.md
+++ b/project_generation/README.md
@@ -33,9 +33,11 @@ This tool can be used in conjunction with the repository creation tool, for furt
 Although these flags are optional, for most, if they are not provided then the user will be prompted for details.
 
 - --name :              The name of the application, if Dissemination specific application it should be prepended with 'dis-'
+- --description:        Description for the application
 - --go-version :        The version of Go the application should use (Not used on generic-projects)
 - --project-location :  Location to generate project in
 - --create-repository : Should a repository be created for the project, default no. Value can be y/Y/yes/YES/ or n/N/no/NO
+- --port :              Port number for the application
 - --type :              Type of application to generate, values can be: `generic-project`, `base-application`, `api`, `controller`, `event-driven`, `library`
 - --team-slugs :        Comma separated list of team slugs for ownership
 

--- a/project_generation/content/templates/base-app/README.md.tmpl
+++ b/project_generation/content/templates/base-app/README.md.tmpl
@@ -1,7 +1,8 @@
 # {{.Name}}
+
 {{.Description}}
 
-### Getting started
+## Getting started
 
 * Run `make debug` to run application on http://localhost:{{.Port}}
 * Run `make help` to see full list of make targets
@@ -23,11 +24,11 @@
 | OTEL_BATCH_TIMEOUT           | 5s                 | Timeout for OpenTelemetry
 | OTEL_ENABLED                 | false              | Feature flag to enable OpenTelemetry
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
 Copyright © {{.Year}}, Office for National Statistics (https://www.ons.gov.uk)
 

--- a/project_generation/content/templates/controller/README.md.tmpl
+++ b/project_generation/content/templates/controller/README.md.tmpl
@@ -1,7 +1,8 @@
 # {{.Name}}
+
 {{.Description}}
 
-### Getting started
+## Getting started
 
 * Run `make debug` to run application on http://localhost:{{.Port}}
 * Run * Run `make help` to see full list of make targets
@@ -24,11 +25,11 @@
 | OTEL_BATCH_TIMEOUT           | 5s                 | Timeout for OpenTelemetry
 | OTEL_ENABLED                 | false              | Feature flag to enable OpenTelemetry
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
 Copyright © {{.Year}}, Office for National Statistics (https://www.ons.gov.uk)
 

--- a/project_generation/content/templates/event/.golangci.yml.tmpl
+++ b/project_generation/content/templates/event/.golangci.yml.tmpl
@@ -83,10 +83,3 @@ issues:
         - dupl
         - gosec
   new: false
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/project_generation/content/templates/event/README.md.tmpl
+++ b/project_generation/content/templates/event/README.md.tmpl
@@ -1,7 +1,8 @@
 # {{.Name}}
+
 {{.Description}}
 
-### Getting started
+## Getting started
 
 * Run `make debug` to run application on http://localhost:{{.Port}}
 * Run `make help` to see full list of make targets
@@ -40,7 +41,7 @@ An example event can be created using the helper script, `make produce`.
 
 [kafka TLS doc]: https://github.com/ONSdigital/dp-kafka/tree/main/examples#tls
 
-### Healthcheck
+## Healthcheck
 
  The `/health` endpoint returns the current status of the service. Dependent services are health checked on an interval defined by the `HEALTHCHECK_INTERVAL` environment variable.
 
@@ -48,11 +49,11 @@ An example event can be created using the helper script, `make produce`.
 
  `curl localhost:8125/health`
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
 Copyright © {{.Year}}, Office for National Statistics (https://www.ons.gov.uk)
 

--- a/project_generation/content/templates/event/schema/schema.go.tmpl
+++ b/project_generation/content/templates/event/schema/schema.go.tmpl
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"github.com/ONSdigital/go-ns/avro"
+	"github.com/ONSdigital/dp-kafka/v4/avro"
 )
 
 

--- a/project_generation/content/templates/event/service/initialise.go.tmpl
+++ b/project_generation/content/templates/event/service/initialise.go.tmpl
@@ -71,6 +71,9 @@ func (e *Init) DoGetKafkaConsumer(ctx context.Context, kafkaCfg *config.KafkaCon
 	cgConfig := &dpkafka.ConsumerGroupConfig{
 		KafkaVersion: &kafkaCfg.Version,
 		Offset:       &kafkaOffset,
+		Topic:        kafkaCfg.HelloCalledTopic,
+		GroupName:    kafkaCfg.HelloCalledGroup,
+		BrokerAddrs:  kafkaCfg.Brokers,
 	}
 	if kafkaCfg.SecProtocol == config.KafkaTLSProtocolFlag {
 		cgConfig.SecurityConfig = dpkafka.GetSecurityConfig(

--- a/project_generation/content/templates/generic/README.md.tmpl
+++ b/project_generation/content/templates/generic/README.md.tmpl
@@ -1,17 +1,18 @@
 # {{.Name}}
+
 {{.Description}}
 
-### Getting started
+## Getting started
 
 ### Dependencies
 
 ### Configuration
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
 Copyright © {{.Year}}, Office for National Statistics (https://www.ons.gov.uk)
 


### PR DESCRIPTION
### What

Removed go-ns, replaced with dp-kafka/v4
Added missing flags from project gen readme
Added missing kafka config

### How to review

Check looks ok. 

Can run by doing
```
make install
cd ..
dp generate-project --name=test-event4 --go-version=1.23.2 --project-location=test-event --type=event-driven --team-slugs=dis1 --description=testymctest --port=2000
cd test-event/test-event4
make debug
```
(may require go.mod modification - not sure why it's coming out with the patch number but that's not my change)

### Who can review

Not me. 