### PR TITLE
Fix/permission setting

### DIFF
--- a/command/generate.go
+++ b/command/generate.go
@@ -84,7 +84,7 @@ func RunGenerateApplication(cmd *cobra.Command, args []string) (err error) {
 			Validator: project_generation.ValidateTeamSlugs,
 		}
 		listOfArguments["projectLanguage"] = &project_generation.Argument{
-			InputVal:  teamSlugs,
+			InputVal:  projectLanguage,
 			Context:   ctx,
 			Validator: project_generation.ValidateProjectLanguage,
 		}

--- a/project_generation/content/templates/generic/.github/ISSUES_TEMPLATE.md.tmpl
+++ b/project_generation/content/templates/generic/.github/ISSUES_TEMPLATE.md.tmpl
@@ -12,7 +12,8 @@ Provide a detailed step by step method on how to reliably recreate the issue
 
 ### Environment information
 
-Provide information relevant to the issue such as 
+Provide information relevant to the issue such as:
+
 * Operating system
 * Browser
 * Relevant environment variables

--- a/project_generation/content/templates/generic/CONTRIBUTING.md.tmpl
+++ b/project_generation/content/templates/generic/CONTRIBUTING.md.tmpl
@@ -1,7 +1,6 @@
-Contributing guidelines
-=======================
+# Contributing guidelines
 
-### Git workflow
+## Git workflow
 
 * We use git-flow - create a feature branch from `develop`, e.g. `feature/new-feature`
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change

--- a/project_generation/content/templates/library/go/CONTRIBUTING.md.tmpl
+++ b/project_generation/content/templates/library/go/CONTRIBUTING.md.tmpl
@@ -1,0 +1,8 @@
+# Contributing guidelines
+
+## Git workflow
+
+* We use trunk based development approach - create a feature branch from `main`, e.g. `feature/new-feature`
+* Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
+* Ensure your branch contains logical atomic commits before sending a pull request - follow the [alphagov Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
+* You may rebase your branch after feedback if it's to include relevant updates from the develop branch. We prefer a rebase here to a merge commit as we prefer a clean and straight history on develop with discrete merge commits for features

--- a/project_generation/content/templates/library/javascript/CONTRIBUTING.md.tmpl
+++ b/project_generation/content/templates/library/javascript/CONTRIBUTING.md.tmpl
@@ -1,7 +1,6 @@
-Contributing guidelines
-=======================
+# Contributing guidelines
 
-### Git workflow
+## Git workflow
 
 * We use a trunk-based development approach - create a feature branch from main, e.g. `feature/new-feature`
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change

--- a/repository_creation/create_repository.go
+++ b/repository_creation/create_repository.go
@@ -319,9 +319,9 @@ func getConfigurationsForNewRepo(name, description string, projType project_gene
 	}
 	if teamSlugsInput == "" {
 		prompt := "Please set at least one team in a comma separated list who will be responsible for this repo."
-		repoTeamSlugsInput = PromptForInput(prompt)
+		teamSlugsInput = PromptForInput(prompt)
 	}
-	return accessToken, repoName, repoDescription, defaultBranch, repoTeamSlugsInput
+	return accessToken, repoName, repoDescription, defaultBranch, teamSlugsInput
 }
 
 // PromptForInput gives a user a message and expect input to be provided


### PR DESCRIPTION
### What

Fixed team slugs not getting properly passed to the repo generation causing team not to be assigned the maintainer role. 

Some other minor changes including markdown formatting

### How to review

Generate a repo and see what it does. I used:

```
dp generate-project --create-repository yes --description "Test" --name dis-cli-test-repo-fixed --port 7777 --project-location . --type generic-project --team-slugs dissemination-open-sauce --project-language go
```

Which you can see here: https://github.com/ONSdigital/dis-cli-test-repo-fixed

### Who can review

If you are a non-tech lead this will require a tech lead to show you the permissions screen, or you can compare you permissions / access to the 'Settings' screen with other repos. 