### PR TITLE
Migrating to dis-design-system-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 	go test -race -cover ./...
 
 audit:
-	go list -m all | nancy sleuth
+	dis-vulncheck
 
 lint:
 	exit

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ In order to use the `dp import cmd` sub-command (e.g. when you are using **Neo4j
   git clone git@github.com:ONSdigital/dp-hierarchy-builder
   ```
 
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
 ### Configuration
 
 Configuration is defined in a YAML file:

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.9-bookworm
 
 inputs:
   - name: dp-cli

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.9-bookworm
 
 inputs:
   - name: dp-cli

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.9-bookworm
 
 inputs:
   - name: dp-cli

--- a/project_generation/content/templates/base-app/Makefile.tmpl
+++ b/project_generation/content/templates/base-app/Makefile.tmpl
@@ -17,7 +17,7 @@ all: delimiter-AUDIT audit delimiter-LINTERS lint delimiter-UNIT-TESTS test deli
 
 .PHONY: audit
 audit: ## Runs checks for security vulnerabilities on dependencies (including transient ones)
-	go list -json -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build: ## Builds binary of application code and stores in bin directory as {{.Name}}
@@ -41,11 +41,7 @@ fmt: ## Run Go formatting on code
 	go fmt ./...
 
 .PHONY: lint
-lint: ## Used in ci to run linters against Go code
-	golangci-lint run ./...
-
-.PHONY: lint-local
-lint-local: ## Use locally to run linters against Go code
+lint:
 	golangci-lint run ./...
 
 .PHONY: test

--- a/project_generation/content/templates/base-app/README.md.tmpl
+++ b/project_generation/content/templates/base-app/README.md.tmpl
@@ -24,6 +24,14 @@
 | OTEL_BATCH_TIMEOUT           | 5s                 | Timeout for OpenTelemetry
 | OTEL_ENABLED                 | false              | Feature flag to enable OpenTelemetry
 
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/project_generation/content/templates/base-app/ci/audit.yml.tmpl
+++ b/project_generation/content/templates/base-app/ci/audit.yml.tmpl
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/project_generation/content/templates/controller/.golangci.yml.tmpl
+++ b/project_generation/content/templates/controller/.golangci.yml.tmpl
@@ -1,107 +1,85 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  revive:
-    rules:
-      # disabled as parameter names are useful for context even when unused, especially in interface implementations
-      - name: unused-parameter
-        severity: warning
-        disabled: true
-    include:
-      - "**/*_test.go" # Specify test files to include
-  funlen:
-  # lines: 100
-  # statements: 100
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-    - path: main.go
-      linters:
-        - typecheck # assets may not exist as they are auto generated
-    - path: utils/service.go
-      linters:
-        - typecheck # assets may not exist as they are auto generated
-    - path: features/steps/example_component.go
-      linters:
-        - typecheck # assets may not exist as they are auto generated
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/project_generation/content/templates/controller/Makefile.tmpl
+++ b/project_generation/content/templates/controller/Makefile.tmpl
@@ -9,22 +9,24 @@ RESET  := $(shell tput -Txterm sgr0)
 BUILD_TIME=$(shell date +%s)
 GIT_COMMIT=$(shell git rev-parse HEAD)
 VERSION ?= $(shell git tag --points-at HEAD | grep ^v | head -n 1)
-LOCAL_DP_RENDERER_IN_USE = $(shell grep -c "\"github.com/ONSdigital/dp-renderer/v2\" =" go.mod)
+LOCAL_RENDERER_IN_USE = $(shell grep -c "\"github.com/ONSdigital/dis-design-system-go\" =" go.mod)
 
+CONFIG_PATH = github.com/ONSdigital/{{.Name}}/config
 SERVICE_PATH = github.com/ONSdigital/{{.Name}}/service
 
-LDFLAGS = -ldflags "-X $(SERVICE_PATH).BuildTime=$(BUILD_TIME) -X $(SERVICE_PATH).GitCommit=$(GIT_COMMIT) -X $(SERVICE_PATH).Version=$(VERSION)"
+LDFLAGS_DEBUG = -ldflags "-X $(SERVICE_PATH).BuildTime=$(BUILD_TIME) -X $(SERVICE_PATH).GitCommit=$(GIT_COMMIT) -X $(SERVICE_PATH).Version=$(VERSION)"
+LDFLAGS_BUILD = -ldflags "-X $(SERVICE_PATH).BuildTime=$(BUILD_TIME) -X $(SERVICE_PATH).GitCommit=$(GIT_COMMIT) -X $(SERVICE_PATH).Version=$(VERSION) -X $(CONFIG_PATH).RendererVersion=$(APP_RENDERER_VERSION)"
 
 .PHONY: all
 all: delimiter-AUDIT audit delimiter-LINTERS lint delimiter-UNIT_TESTS test delimiter-COMPONENT_TESTS test-component delimiter-FINISH ## Runs multiple targets, audit, lint, test and test-component
 
 .PHONY: audit
-audit: ## Runs checks for security vulnerabilities on dependencies (including transient ones)
-	go list -json -m all | nancy sleuth
+audit: generate-prod ## Runs checks for security vulnerabilities on dependencies (including transient ones)
+	dis-vulncheck --build-tags=production
 
 .PHONY: build
 build: generate-prod ## Builds binary of application code and stores in bin directory as {{.Name}}
-	go build -tags 'production' $(LDFLAGS) -o $(BINPATH)/{{.Name}}
+	go build -tags 'production' $(LDFLAGS_BUILD) -o $(BINPATH)/{{.Name}}
 
 .PHONY: convey
 convey: ## Runs unit test suite and outputs results on http://127.0.0.1:8080/
@@ -32,7 +34,7 @@ convey: ## Runs unit test suite and outputs results on http://127.0.0.1:8080/
 
 .PHONY: debug
 debug: generate-debug ## Used to run code locally in debug mode
-	go build -tags 'debug' $(LDFLAGS) -o $(BINPATH)/{{.Name}}
+	go build -tags 'debug' $(LDFLAGS_DEBUG) -o $(BINPATH)/{{.Name}}
 	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/{{.Name}}
 
 .PHONY: delimiter-%
@@ -44,17 +46,8 @@ fmt: ## Run Go formatting on code
 	go fmt ./...
 
 .PHONY: lint
-lint: ## Used in ci to run linters against Go code
-	cp assets/assets.go assets/assets.go.bak
-	echo 'func Asset(_ string) ([]byte, error) { return nil, nil }' >> assets/assets.go
-	echo 'func AssetNames() []string { return []string{} }' >> assets/assets.go
-	gofmt -w assets/assets.go
-	golangci-lint run ./... || { echo "Linting failed, restoring original assets.go"; mv assets/assets.go.bak assets/assets.go; exit 1; }
-	mv assets/assets.go.bak assets/assets.go
-
-.PHONY: lint-local
-lint-local: ## Use locally to run linters against Go code
-	golangci-lint run ./...
+lint: generate-prod
+	golangci-lint run ./... --build-tags 'production'
 
 .PHONY: test
 test: generate-prod ## Runs unit tests including checks for race conditions and returns coverage
@@ -64,23 +57,23 @@ test: generate-prod ## Runs unit tests including checks for race conditions and 
 test-component: generate-prod ## Runs component test suite
 	go test -cover -tags 'production' -coverpkg=github.com/ONSdigital/dp-hello-world-controller/... -component
 
-.PHONY: fetch-renderer-lib
-fetch-renderer-lib:
-ifeq ($(LOCAL_DP_RENDERER_IN_USE), 1)
- $(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dp-renderer/v2\" =>" go.mod | awk -F '=> ' '{print $$2}' | tr -d '"'))
+.PHONY: fetch-renderer
+fetch-renderer:
+ifeq ($(LOCAL_RENDERER_IN_USE), 1)
+ $(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dis-design-system-go\" =>" go.mod | awk -F '=> ' '{print $$2}' | tr -d '"'))
 else
- $(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dp-renderer/v2" go.mod | cut -d ' ' -f2 ))
- $(eval CORE_ASSETS_PATH = $(shell go get github.com/ONSdigital/dp-renderer/v2@$(APP_RENDERER_VERSION) && go list -f {{"'{{.Dir}}'"}} -m github.com/ONSdigital/dp-renderer/v2))
+ $(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dis-design-system-go" go.mod | cut -d ' ' -f2 ))
+ $(eval CORE_ASSETS_PATH = $(shell go get github.com/ONSdigital/dis-design-system-go@$(APP_RENDERER_VERSION) && go list -f {{"'{{.Dir}}'"}} -m github.com/ONSdigital/dis-design-system-go))
 endif
 
 .PHONY: generate-debug
-generate-debug: fetch-renderer-lib
+generate-debug: fetch-renderer
 	cd assets; go run github.com/kevinburke/go-bindata/v4/...@latest -prefix $(CORE_ASSETS_PATH)/assets -debug -o data.go -pkg assets locales/... templates/... $(CORE_ASSETS_PATH)/assets/locales/... $(CORE_ASSETS_PATH)/assets/templates/...
 	{ echo "// +build debug\n"; cat assets/data.go; } > assets/debug.go.new
 	mv assets/debug.go.new assets/data.go
 
 .PHONY: generate-prod
-generate-prod: fetch-renderer-lib 
+generate-prod: fetch-renderer
 	cd assets; go run github.com/kevinburke/go-bindata/v4/...@latest -prefix $(CORE_ASSETS_PATH)/assets -o data.go -pkg assets locales/... templates/... $(CORE_ASSETS_PATH)/assets/locales/... $(CORE_ASSETS_PATH)/assets/templates/...
 	{ echo "// +build production\n"; cat assets/data.go; } > assets/data.go.new
 	mv assets/data.go.new assets/data.go

--- a/project_generation/content/templates/controller/README.md.tmpl
+++ b/project_generation/content/templates/controller/README.md.tmpl
@@ -4,12 +4,25 @@
 
 ## Getting started
 
+* Run [`dis-design-system-go`](https://github.com/ONSdigital/dis-design-system-go) in a separate shell to generate static assets (css/js) 
 * Run `make debug` to run application on http://localhost:{{.Port}}
 * Run * Run `make help` to see full list of make targets
 
 ### Dependencies
 
 * No further dependencies other than those defined in `go.mod`
+
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
 
 ### Configuration
 

--- a/project_generation/content/templates/controller/config/config.go.tmpl
+++ b/project_generation/content/templates/controller/config/config.go.tmpl
@@ -2,6 +2,7 @@ package config
 
 import (
 	"time"
+	"fmt"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -24,6 +25,8 @@ type Config struct {
 }
 
 var cfg *Config
+
+var RendererVersion = "v0.2.0"
 
 // Get returns the default config with any modifications through environment
 // variables
@@ -49,7 +52,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/75d8ed9"
+		cfg.PatternLibraryAssetsPath = fmt.Sprintf("//cdn.ons.gov.uk/dis-design-system-go/%s", RendererVersion)
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/project_generation/content/templates/controller/features/steps/example_component.go.tmpl
+++ b/project_generation/content/templates/controller/features/steps/example_component.go.tmpl
@@ -9,7 +9,7 @@ import (
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
-	render "github.com/ONSdigital/dp-renderer/v2"
+	render "github.com/ONSdigital/dis-design-system-go"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/ONSdigital/{{.Name}}/assets"
 	"github.com/ONSdigital/{{.Name}}/config"

--- a/project_generation/content/templates/controller/handlers/clients.go.tmpl
+++ b/project_generation/content/templates/controller/handlers/clients.go.tmpl
@@ -3,7 +3,7 @@ package handlers
 import (
 	"io"
 
-	"github.com/ONSdigital/dp-renderer/v2/model"
+	"github.com/ONSdigital/dis-design-system-go/model"
 )
 
 //go:generate moq -out clients_mock.go -pkg handlers . ClientError RenderClient

--- a/project_generation/content/templates/controller/main.go.tmpl
+++ b/project_generation/content/templates/controller/main.go.tmpl
@@ -12,7 +12,7 @@ import (
 	"github.com/ONSdigital/{{.Name}}/config"
 	"github.com/ONSdigital/{{.Name}}/service"
 	dpotelgo "github.com/ONSdigital/dp-otel-go"
-	render "github.com/ONSdigital/dp-renderer/v2"
+	render "github.com/ONSdigital/dis-design-system-go"
 	"github.com/ONSdigital/log.go/v2/log"
 )
 

--- a/project_generation/content/templates/controller/mapper/mapper.go.tmpl
+++ b/project_generation/content/templates/controller/mapper/mapper.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/{{.Name}}/config"
-	"github.com/ONSdigital/dp-renderer/v2/model"
+	"github.com/ONSdigital/dis-design-system-go/model"
 )
 
 // TODO: remove hello world example mapper and models

--- a/project_generation/content/templates/controller/mapper/mapper_test.go.tmpl
+++ b/project_generation/content/templates/controller/mapper/mapper_test.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/{{.Name}}/config"
-	"github.com/ONSdigital/dp-renderer/v2/model"
+	"github.com/ONSdigital/dis-design-system-go/model"
 	. "github.com/smartystreets/goconvey/convey"
 
 )

--- a/project_generation/content/templates/event/Makefile.tmpl
+++ b/project_generation/content/templates/event/Makefile.tmpl
@@ -17,7 +17,7 @@ all: delimiter-AUDIT audit delimiter-LINTERS lint delimiter-UNIT-TESTS test deli
 
 .PHONY: audit
 audit: ## Runs checks for security vulnerabilities on dependencies (including transient ones)
-	go list -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build: ## Builds binary of application code and stores in bin directory as {{.Name}}
@@ -42,10 +42,6 @@ fmt: ## Run Go formatting on code
 
 .PHONY: lint
 lint: ## Used in ci to run linters against Go code
-	golangci-lint run ./...
-
-.PHONY: lint-local
-lint-local: ## Use locally to run linters against Go code
 	golangci-lint run ./...
 
 .PHONY: produce

--- a/project_generation/content/templates/event/README.md.tmpl
+++ b/project_generation/content/templates/event/README.md.tmpl
@@ -16,6 +16,14 @@ An example event can be created using the helper script, `make produce`.
   * [kafka](https://github.com/ONSdigital/dp/blob/main/guides/INSTALLING.md#prerequisites)
 * No further dependencies other than those defined in `go.mod`
 
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
 ### Configuration
 
 | Environment variable         | Default                           | Description

--- a/project_generation/content/templates/library/go/Makefile.tmpl
+++ b/project_generation/content/templates/library/go/Makefile.tmpl
@@ -9,7 +9,7 @@ all: delimiter-AUDIT audit delimiter-UNIT-TESTS test delimiter-LINTERS lint deli
 
 .PHONY: audit
 audit: ## Runs checks for security vulnerabilities on dependencies (including transient ones)
-	go list -json -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build: ## Builds binary of library code as {{.Name}}
@@ -29,10 +29,6 @@ fmt: ## Run Go formatting on code
 
 .PHONY: lint
 lint: ## Used in ci to run linters against Go code
-	golangci-lint run ./...
-
-.PHONY: lint-local
-lint-local: ## Use locally to run linters against Go code
 	golangci-lint run ./...
 
 .PHONY: test

--- a/project_generation/content/templates/library/go/README.md.tmpl
+++ b/project_generation/content/templates/library/go/README.md.tmpl
@@ -10,6 +10,14 @@
 
 * No further dependencies other than those defined in `go.mod`
 
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
 ### Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/project_generation/content/templates/library/go/ci/audit.yml.tmpl
+++ b/project_generation/content/templates/library/go/ci/audit.yml.tmpl
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -492,7 +492,7 @@ func OptionPromptInput(ctx context.Context, prompt string, options ...string) (s
 }
 
 // InitGoModules will initialise the go modules for a project at a given directory unless go.mod already exists
-func InitGoModules(ctx context.Context, pathToRepo, name string) error {
+func InitGoModules(ctx context.Context, pathToRepo, name string, goVersion string) error {
 	_, err := os.Stat(pathToRepo + "/go.mod")
 	if os.IsExist(err) {
 		return err // file already exists but there's some other error with it
@@ -500,7 +500,10 @@ func InitGoModules(ctx context.Context, pathToRepo, name string) error {
 	if err == nil {
 		return nil // file already exists, do nothing
 	}
-
+	err = os.Setenv("GOTOOLCHAIN", "go"+goVersion)
+	if err != nil {
+		return err
+	}
 	cmd := exec.Command("go", "mod", "init", "github.com/ONSdigital/"+name)
 	cmd.Dir = pathToRepo
 	err = cmd.Run()

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -510,6 +510,14 @@ func InitGoModules(ctx context.Context, pathToRepo, name string, goVersion strin
 	if err != nil {
 		log.Error(ctx, "error initialising go modules", err)
 	}
+	// Reset the go minimum version to the 0 patch
+	minVersion := goVersion[:strings.LastIndex(goVersion, ".")] + ".0"
+	cmd = exec.Command("go", "mod", "edit", "-go="+minVersion)
+	cmd.Dir = pathToRepo
+	err = cmd.Run()
+	if err != nil {
+		log.Error(ctx, "error setting go module minimum version", err)
+	}
 	return nil
 }
 

--- a/project_generation/project_generation.go
+++ b/project_generation/project_generation.go
@@ -90,7 +90,7 @@ func GenerateProject(appName, appDesc, projType, projectLocation, runtimeVer, po
 			return err
 		}
 	case BaseApplication:
-		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name)
+		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name, rv)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func GenerateProject(appName, appDesc, projType, projectLocation, runtimeVer, po
 		FinaliseModules(ctx, newApp.pathToRepo)
 		FormatGoFiles(ctx, newApp.pathToRepo)
 	case API:
-		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name)
+		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name, rv)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func GenerateProject(appName, appDesc, projType, projectLocation, runtimeVer, po
 		FinaliseModules(ctx, newApp.pathToRepo)
 		FormatGoFiles(ctx, newApp.pathToRepo)
 	case Controller:
-		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name)
+		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name, rv)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func GenerateProject(appName, appDesc, projType, projectLocation, runtimeVer, po
 		FinaliseModules(ctx, newApp.pathToRepo, AppOptions{Type: Controller})
 		FormatGoFiles(ctx, newApp.pathToRepo)
 	case EventDriven:
-		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name)
+		err := InitGoModules(ctx, newApp.pathToRepo, newApp.name, rv)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func GenerateProject(appName, appDesc, projType, projectLocation, runtimeVer, po
 		FormatGoFiles(ctx, newApp.pathToRepo)
 	case Library:
 		if plang == "go" {
-			err := InitGoModules(ctx, newApp.pathToRepo, newApp.name)
+			err := InitGoModules(ctx, newApp.pathToRepo, newApp.name, rv)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What

[Migrated to dis-design-system-go for controller](https://officefornationalstatistics.atlassian.net/browse/DIS-3380?atlOrigin=eyJpIjoiNzYwMWJmMGZmMDE2NDg0ODlhYTRmMmVlNzVlZTY0YzEiLCJwIjoiaiJ9)
User specified go version used for go.mod
Migrated linter to v2 for controller
Switch to vulncheck

### How to review

Ensure tests pass
Confirm everything looks okay/in place
Sense check

**To generate a controller:**
- Pull this branch
- Run `make build`
- In your terminal add this version of dp to your PATH: `export PATH=/dp-cli:$PATH` (relative to where you are to dp-cli)
- Run `dp generate-project`
- Ensure all tests pass for the generated project and no mention of `dp-renderer` or `dp-design-system` is made

### Who can review

Not me