### PR TITLE
reset go.mod version to 0 patch on project gen

### DIFF
--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -500,7 +500,8 @@ func InitGoModules(ctx context.Context, pathToRepo, name string, goVersion strin
 	if err == nil {
 		return nil // file already exists, do nothing
 	}
-	err = os.Setenv("GOTOOLCHAIN", "go"+goVersion)
+	minVersion := goVersion[:strings.LastIndex(goVersion, ".")] + ".0"
+	err = os.Setenv("GOTOOLCHAIN", "go"+minVersion)
 	if err != nil {
 		return err
 	}
@@ -509,14 +510,6 @@ func InitGoModules(ctx context.Context, pathToRepo, name string, goVersion strin
 	err = cmd.Run()
 	if err != nil {
 		log.Error(ctx, "error initialising go modules", err)
-	}
-	//Reset the go minimum version to the 0 patch
-	minVersion := goVersion[:strings.LastIndex(goVersion, ".")] + ".0"
-	cmd = exec.Command("go", "mod", "edit", "-go="+minVersion)
-	cmd.Dir = pathToRepo
-	err = cmd.Run()
-	if err != nil {
-		log.Error(ctx, "error setting go module minimum version", err)
 	}
 	return nil
 }

--- a/project_generation/helpers.go
+++ b/project_generation/helpers.go
@@ -510,6 +510,14 @@ func InitGoModules(ctx context.Context, pathToRepo, name string, goVersion strin
 	if err != nil {
 		log.Error(ctx, "error initialising go modules", err)
 	}
+	//Reset the go minimum version to the 0 patch
+	minVersion := goVersion[:strings.LastIndex(goVersion, ".")] + ".0"
+	cmd = exec.Command("go", "mod", "edit", "-go="+minVersion)
+	cmd.Dir = pathToRepo
+	err = cmd.Run()
+	if err != nil {
+		log.Error(ctx, "error setting go module minimum version", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
### What

Edited the go mod post initialisation to set the patch version of the minimum version to 0 

ie. instead of the specific version in the ci build (eg. 1.24.6) it will still build using that version but the go mod will specify a minimum required version of `1.24.0`

### How to review

See if you like it

### Who can review

Aqdas really