### PR TITLE
Migrate linter configs within templates to v2

### DIFF
--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -eux
 
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
-
 pushd dp-cli
   make lint
 popd

--- a/project_generation/content/templates/api/.golangci.yml.tmpl
+++ b/project_generation/content/templates/api/.golangci.yml.tmpl
@@ -1,98 +1,88 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  revive:
-    rules:
-      # disabled as parameter names are useful for context even when unused, especially in interface implementations
-      - name: unused-parameter
-        severity: warning
-        disabled: true
-    include:
-      - "**/*_test.go" # Specify test files to include
-  funlen:
-  # lines: 100
-  # statements: 100
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/project_generation/content/templates/base-app/.golangci.yml.tmpl
+++ b/project_generation/content/templates/base-app/.golangci.yml.tmpl
@@ -1,99 +1,88 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  revive:
-    rules:
-      # disabled as parameter names are useful for context even when unused, especially in interface implementations
-      - name: unused-parameter
-        severity: warning
-        disabled: true
-    include:
-      - "**/*_test.go" # Specify test files to include
-  funlen:
-  # lines: 100
-  # statements: 100
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
-
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/project_generation/content/templates/base-app/README.md.tmpl
+++ b/project_generation/content/templates/base-app/README.md.tmpl
@@ -32,6 +32,10 @@ To run some of our tests you will need additional tooling:
 
 We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
 
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/project_generation/content/templates/base-app/ci/scripts/lint.sh.tmpl
+++ b/project_generation/content/templates/base-app/ci/scripts/lint.sh.tmpl
@@ -1,7 +1,5 @@
 #!/bin/bash -eux
 
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
-
 pushd {{.Name}}
   make lint
 popd

--- a/project_generation/content/templates/event/.golangci.yml.tmpl
+++ b/project_generation/content/templates/event/.golangci.yml.tmpl
@@ -1,98 +1,88 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  funlen:
-  # lines: 100
-  # statements: 100
-  revive:
-    rules:
-      # disabled as parameter names are useful for context even when unused, especially in interface implementations
-      - name: unused-parameter
-        severity: warning
-        disabled: true
-    include:
-      - "**/*_test.go" # Specify test files to include
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/project_generation/content/templates/event/README.md.tmpl
+++ b/project_generation/content/templates/event/README.md.tmpl
@@ -24,6 +24,10 @@ To run some of our tests you will need additional tooling:
 
 We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
 
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
+
 ### Configuration
 
 | Environment variable         | Default                           | Description

--- a/project_generation/content/templates/library/go/.golangci.yml.tmpl
+++ b/project_generation/content/templates/library/go/.golangci.yml.tmpl
@@ -1,98 +1,88 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  funlen:
-  # lines: 100
-  # statements: 100
-  revive:
-    rules:
-      # disabled as parameter names are useful for context even when unused, especially in interface implementations
-      - name: unused-parameter
-        severity: warning
-        disabled: true
-    include:
-      - "**/*_test.go" # Specify test files to include
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/project_generation/content/templates/library/go/README.md.tmpl
+++ b/project_generation/content/templates/library/go/README.md.tmpl
@@ -18,6 +18,10 @@ To run some of our tests you will need additional tooling:
 
 We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
 
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
+
 ### Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/project_generation/content/templates/library/go/ci/scripts/lint.sh.tmpl
+++ b/project_generation/content/templates/library/go/ci/scripts/lint.sh.tmpl
@@ -1,7 +1,5 @@
 #!/bin/bash -eux
 
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
-
 pushd {{.Name}}
   make lint
 popd


### PR DESCRIPTION
### What

[Migrated linter configs within template to v2](https://officefornationalstatistics.atlassian.net/browse/DIS-4218?atlOrigin=eyJpIjoiYmQwZTQ2YWZlNzk1NDIyOWI3NTljMWRiNWQ0NDA1MzQiLCJwIjoiaiJ9)

### How to review

Sense check
Confirm everything looks okay/in place

**To test:**
- Pull this branch
- Run `make build`
- In your terminal add this version of dp to your PATH: `export PATH=/dp-cli:$PATH` (relative to where you are to dp-cli)
- Run `dp generate-project` and generate all templates below
- Run `make lint` within each of the generated templates and ensure there are 0 issues

### Who can review

Not me